### PR TITLE
Rather than calling getMap when initializing the controller for the Coun...

### DIFF
--- a/nwc/src/main/webapp/client/nwc/workflows/waterBudget/waterBudgetControllers.js
+++ b/nwc/src/main/webapp/client/nwc/workflows/waterBudget/waterBudgetControllers.js
@@ -60,14 +60,14 @@ waterBudgetControllers.controller('PlotData', ['$scope', '$state', 'StoredState'
             	var countyVectorLayer = new OpenLayers.Layer.Vector("Simple Geometry County", {
                 	style: layerStyle
             	});
-            	
+
             	var countyFeature = new OpenLayers.Feature.Vector(StoredState.countyFeature.geometry);
             	countyVectorLayer.addFeatures([hucFeature.clone(), countyFeature]);
 
     			$scope.countyLayer = [countyVectorLayer];
     			$scope.countyBounds = StoredState.countyFeature.geometry.getBounds();
             }
-			
+
             var selectionInfo = {};
             if (StoredState.waterBudgetHucFeature) {
                 selectionInfo.hucId = StoredState.waterBudgetHucFeature.data.HUC_12;
@@ -263,13 +263,12 @@ waterBudgetControllers.controller('SelectCounty', ['$scope', 'StoredState', 'Com
         $scope.CommonState = CommonState;
         $scope.isCountySelectionPage = true;
 
-        var map = WaterBudgetMap.getMap();
+        var map = WaterBudgetMap.initMap();
+		map.zoomToExtent(StoredState.mapExtent, true);
         map.render('hucSelectMap');
         map.getCountyThatIntersectsWithHucFeature(StoredState.waterBudgetHucFeature, function() {
         	  	$scope.$digest();
         	});
-
-        map.zoomToExtent(StoredState.mapExtent, true);
         map.events.register(
             'moveend',
             map,

--- a/nwc/src/main/webapp/client/nwc/workflows/waterBudget/waterBudgetMap.js
+++ b/nwc/src/main/webapp/client/nwc/workflows/waterBudget/waterBudgetMap.js
@@ -2,11 +2,11 @@
 (function () {
     var waterBudgetMap = angular.module('nwc.map.waterBudget', ['ui.router', 'nwc.map.base']);
 	var myHucLayerName = "National WBD Snapshot";
-	
+
     waterBudgetMap.factory('WaterBudgetMap', [ 'StoredState', 'CommonState', '$state', '$log', 'BaseMap', 'DataSeries', 'HucCountiesIntersector',
        function(StoredState, CommonState, $state, $log, BaseMap, DataSeries, HucCountiesIntersector){
            var privateMap;
-    
+
         var initMap = function () {
             var mapLayers = [];
             var controls = [];
@@ -20,10 +20,11 @@
                         styles: ['polygon'],
                         tiled: true
                     },
-            hucLayerOptions
+					hucLayerOptions
                     );
+
             mapLayers.push(hucLayer);
-            
+
             // ////////////////////////////////////////////// FLOWLINES
             var flowlinesData = new OpenLayers.Layer.FlowlinesData(
                     "Flowline WMS (Data)",
@@ -41,7 +42,7 @@
 
             mapLayers.push(flowlinesData);
             mapLayers.push(flowlineRaster);
-            
+
             var hucsGetFeatureInfoControl = new OpenLayers.Control.WMSGetFeatureInfo({
                     title: 'huc-identify-control',
                     hover: false,
@@ -58,8 +59,8 @@
                     id: 'nwc-hucs',
                     autoActivate: true
                 });
-                
-                
+
+
                 var featureInfoHandler = function (responseObject) {
                     //for some reason the real features are inside an array
                     var actualFeatures = responseObject.features[0].features;
@@ -89,38 +90,38 @@
                 controls.push(new OpenLayers.Control.ZoomBox({
                     id: 'nwc-zoom'
                 }));
-                
+
                 var map = BaseMap.new({
                     layers: mapLayers,
                     controls: controls
                 });
-                
+
                 map.events.register(
                         'zoomend',
                         map,
                         function () {
                             var zoom = map.zoom;
-                            $log.info('Current map zoom: ' + zoom);
                             flowlineRaster.updateFromClipValue(flowlineRaster.getClipValueForZoom(zoom));
                         },
                         true
                 );
-                
+
                 flowlineRaster.setStreamOrderClipValues(map.getNumZoomLevels());
                 flowlineRaster.updateFromClipValue(flowlineRaster.getClipValueForZoom(map.zoom));
-            
-            
+
+
             ///map object methods
-            
+
             //convenience accessor
             var getHucLayer = function () {
                 return hucLayer;
             };
-            
+
             /**
-             * @param {Openlayers.Geometry} geometry The geom of the huc that will be 
+             * @param {Openlayers.Geometry} geometry The geom of the huc that will be
              * used to search for intersections with the counties layer
-             * @returns {Openlayers.Layer.Vector} the vector layer containing the 
+			 * @param {Function} callback This is called after the vector layer's extent is calculated
+             * @returns {Openlayers.Layer.Vector} the vector layer containing the
              * intersecting counties
              */
             var addCountiesThatIntersectWith = function (hucFeature, callback) {
@@ -173,7 +174,6 @@
                         StoredState.mapExtent = countiesExtent;
                         callback();
                         map.zoomToExtent(countiesExtent);
-                        intersectingCountiesLayer.refresh();
                     }
                 );
                 return intersectingCountiesLayer;
@@ -225,7 +225,7 @@
                 map.addControl(control);
                 control.activate();
             };
-            
+
             /**
              * @param {Openlayers.Feature.Vector} hucFeature The huc that a user has selected.
              */
@@ -239,12 +239,12 @@
                         }
                 );
             };
-            
+
             map.getHucLayer = getHucLayer;
             map.getCountyThatIntersectsWithHucFeature = getCountyThatIntersectsWithHucFeature;
             map.addCountySelectControl = addCountySelectControl;
             map.addHighlightedFeature = addHighlightedFeature;
-            
+
             //stash it in a closure var
             privateMap = map;
             privateMap.getCountyThatIntersectsWithHucFeature = getCountyThatIntersectsWithHucFeature;
@@ -254,17 +254,17 @@
             if (!privateMap || !privateMap.viewPortDiv.parentNode) {
                 initMap();
             }
-            
+
             return privateMap;
         };
         return {
             initMap: initMap,
             getMap: getMap,
 			hucLayerName: myHucLayerName
-			
+
         };
-		
-       } 
+
+       }
     ]);
-    
+
 }());


### PR DESCRIPTION
...try Selection StepController, use initMap. The application comes to this step from a route that no longer contains the existing map object's dom element. By calling initMap, the map object is recreated and this avoids problems when displaying the map initially. Removed code that was added to try to work around this issue that is no longer needed.