### PR TITLE
Backed out the update to the version of backbone. There was a change …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,8 @@
 		<jquery.version>1.11.3</jquery.version>
 		<bootstrap.version>3.3.5</bootstrap.version>
 		<select2.version>3.5.4</select2.version>
-		<backbone.version>1.2.1</backbone.version>
+		<!-- Note that if this version is updated to 1.2.X, we will need to address how we are extending views when adding events as we do for BaseSelectMapView-->
+		<backbone.version>1.1.2</backbone.version> 
 		<underscore.version>1.8.3</underscore.version>
 		<handlebars.version>4.0.2</handlebars.version>
 		<flotcharts.version>0.8.3</flotcharts.version>


### PR DESCRIPTION
…in how views delegate their events that occurred with 1.2 release which prevents the initialize function from changing the hash. We will need to address this before updating the backbone version.