### PR TITLE
Watersmart 585

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ nbactions.xml
 .DS_Store
 /nwc/phantomjsdriver.log
 phantomjsdriver.log
+/nwc/etc/
+/nwc/node/
+/nwc/node_modules/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository houses the [National Water Census data portal.](http://cida.usgs
 	<Environment name="nwc.endpoint.searchService" value="http://txpub.usgs.gov/DSS/search_api/1.0/dataService/dataService.ashx/search" type="java.lang.String" override="true"/>
     <Environment name="nwc.endpoint.sciencebase" override="true" type="java.lang.String" value="https://www.sciencebase.gov"/>
 </Context>
-
+'''
 
  -  Fork this repo
  -  Clone your forked repo

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This repository houses the [National Water Census data portal.](http://cida.usgs
 ![alt text](http://cida.usgs.gov/nwc/img/workflow/originals/watershed.svg "National Water Census Data Portal")
 
 ## RUNNING 
- -  Install Java 7, Tomcat 7.
+ -  Install Java 8, Tomcat 7.
  -  Open the context.xml for the instance you are going to run this app in (Either $CATALINA_HOME/conf/context.xml or $CATALINA_BASE/conf/context.xml)
- -  Make your context.xml look like the following, substituting different values as neccessary:
+ -  Make your context.xml look like the following, substituting different values as necessary:
+
 ```xml
+
 <?xml version="1.0" encoding="utf-8"?>
 <Context>
     <!-- Default set of monitored resources -->
@@ -16,16 +18,17 @@ This repository houses the [National Water Census data portal.](http://cida.usgs
 
     <!-- disable session persistence across Tomcat restarts -->
     <Manager pathname="" />
-	<Environment name="nwc.development" value="True" type="java.lang.String" override="true"/>
-	<Environment name="nwc.endpoint.geoserver" value="http://cida-eros-wsdev.er.usgs.gov:8081/geoserver/" type="java.lang.String" override="true"/>
-        <Environment name="nwc.endpoint.thredds" value="http://cida-eros-wsdev.er.usgs.gov:8081/thredds/sos/watersmart/" type="java.lang.String" override="true"/>
-        <Environment name="nwc.endpoint.wps" value="http://cida-eros-wsdev.er.usgs.gov:8081/wps/" type="java.lang.String" override="true"/>
-        <Environment name="nwc.endpoint.nwis" value="http://waterservices.usgs.gov/nwis/site/" type="java.lang.String" override="true"/>
-		<Environment name="nwc.endpoint.nwis.streamflow" value="http://waterservices.usgs.gov/nwis/dv/" type="java.lang.String" override="true"/>
-        <Environment name="nwc.endpoint.searchService" value="http://txpub.usgs.gov/DSS/search_api/1.0/dataService/dataService.ashx/search" type="java.lang.String" override="true"/>
-        <Environment name="nwc.endpoint.sciencebase" override="true" type="java.lang.String" value="https://www.sciencebase.gov"/>
+	<Environment name="nwc.development" value="true" type="java.lang.String" override="true"/>
+	<Environment name="nwc.endpoint.geoserver" value="http://path_to_nwc_geoserver" type="java.lang.String" override="true"/>
+    <Environment name="nwc.endpoint.thredds" value="http://path_to_watersmart_thredds_server" type="java.lang.String" override="true"/>
+    <Environment name="nwc.endpoint.wps" value="http://path_to_watersmart_wps_process_service" type="java.lang.String" override="true"/>
+    <Environment name="nwc.endpoint.nwis" value="http://waterservices.usgs.gov/nwis/site/" type="java.lang.String" override="true"/>
+	<Environment name="nwc.endpoint.nwis.streamflow" value="http://waterservices.usgs.gov/nwis/dv/" type="java.lang.String" override="true"/>
+	<Environment name="nwc.endpoint.searchService" value="http://txpub.usgs.gov/DSS/search_api/1.0/dataService/dataService.ashx/search" type="java.lang.String" override="true"/>
+    <Environment name="nwc.endpoint.sciencebase" override="true" type="java.lang.String" value="https://www.sciencebase.gov"/>
 </Context>
-```
+
+
  -  Fork this repo
  -  Clone your forked repo
  -  change to the directory where you cloned your fork 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository houses the [National Water Census data portal.](http://cida.usgs
 	<Environment name="nwc.endpoint.searchService" value="http://txpub.usgs.gov/DSS/search_api/1.0/dataService/dataService.ashx/search" type="java.lang.String" override="true"/>
     <Environment name="nwc.endpoint.sciencebase" override="true" type="java.lang.String" value="https://www.sciencebase.gov"/>
 </Context>
-'''
+
 
  -  Fork this repo
  -  Clone your forked repo

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository houses the [National Water Census data portal.](http://cida.usgs
 	<Environment name="nwc.endpoint.searchService" value="http://txpub.usgs.gov/DSS/search_api/1.0/dataService/dataService.ashx/search" type="java.lang.String" override="true"/>
     <Environment name="nwc.endpoint.sciencebase" override="true" type="java.lang.String" value="https://www.sciencebase.gov"/>
 </Context>
+```
 
 
  -  Fork this repo

--- a/nwc/src/main/webapp/css/custom.css
+++ b/nwc/src/main/webapp/css/custom.css
@@ -114,9 +114,13 @@ h5, h6 {
         width: 700px;
         padding-left:20px;
 }
+
+#waterbudget-huc-data-container .info-buttons .button-div {
+	display: inline-block;
+}
 .inset-map {
-	height : 200px;
-	width: 200px;
+	height : 300px;
+	width: 300px;
 	border-style: solid;
 	border-width:1px;
 }

--- a/nwc/src/main/webapp/css/custom.css
+++ b/nwc/src/main/webapp/css/custom.css
@@ -120,6 +120,11 @@ h5, h6 {
 	border-style: solid;
 	border-width:1px;
 }
+.inset-legend-container span {
+	position: relative;
+	top : -4px;
+	line-height : 1px;
+}
 
 #statistics-calculation-div {
 	margin-top : 20px;

--- a/nwc/src/main/webapp/js/model/Config.js
+++ b/nwc/src/main/webapp/js/model/Config.js
@@ -253,7 +253,7 @@ NWC.model = NWC.model || {};
 					variables : {
 						dayMet : new NWC.model.SosVariable({
 							observedProperty: 'prcp',
-							propertyLongName: 'Area Weighted Mean Precipitation',
+							propertyLongName: 'Area Weighted Mean Precipitation (Over Hydrologic Unit Code Watershed)',
 							units: NWC.util.Units.metric.normalizedWater.daily,
 							dataset: 'HUC12_data',
 							fileName: 'huc12_daymet_agg.nc',
@@ -261,7 +261,7 @@ NWC.model = NWC.model || {};
 						}),
 						eta : new NWC.model.SosVariable({
 							observedProperty: 'et',
-							propertyLongName: 'Area Weighted Mean Actual Evapotranspiration',
+							propertyLongName: 'Area Weighted Mean Actual Evapotranspiration (Over Hydrologic Unit Code Watershed)',
 							units: NWC.util.Units.metric.normalizedWater.monthly,
 							dataset: 'HUC12_data',
 							fileName: 'huc12_eta_agg.nc',

--- a/nwc/src/main/webapp/js/model/Config.js
+++ b/nwc/src/main/webapp/js/model/Config.js
@@ -111,7 +111,7 @@ NWC.model = NWC.model || {};
 		},
 		getGageId : function(hucId) {
 			return this.lookupByHucId[hucId] ? this.lookupByHucId[hucId].gageId : null;
-		}		
+		}
 	});
 
 	NWC.model.SciencebaseUrlFragmentModel = Backbone.Model.extend({
@@ -192,6 +192,7 @@ NWC.model = NWC.model || {};
 						namespace : 'WBD',
 						property : 'huc12',
 						name : 'name',
+						drainageArea : 'areasqkm',
 						watershedArea : 'DRAIN_SQKM',
 						selectDisplay : '12 Digit',
 						variables : {
@@ -218,6 +219,7 @@ NWC.model = NWC.model || {};
 						namespace : 'WBD',
 						property : 'huc8',
 						name : 'name',
+						drainageArea : 'areasqkm',
 						selectDisplay : '8 Digit',
 						variables : {
 							dayMet : new NWC.model.SosVariable({
@@ -245,6 +247,7 @@ NWC.model = NWC.model || {};
 					namespace : 'WBD',
 					property : 'huc12',
 					name : 'name',
+					drainageArea : 'areasqkm',
 					watershedAreaUnit : 'DRAIN_SQKM',
 					selectDisplay : 'Accumulated',
 					variables : {

--- a/nwc/src/main/webapp/js/utils/mapUtils.js
+++ b/nwc/src/main/webapp/js/utils/mapUtils.js
@@ -134,7 +134,7 @@ NWC.util.mapUtils = (function () {
 	 * @param {OpenLayers.StyleMap} styleMap - optional style map for the feature layer.
 	 * @returns OpenLayers.Layer.Vector with hucs.
 	 */
-	that.createHucFeatureLayer = function(namespace, layerName, property, hucs, styleMap) {
+	that.createHucFeatureLayer = function(namespace, layerName, property, hucs, style) {
 		var filter;
 		var hucFilters = [];
 		var hucLayer;
@@ -146,13 +146,11 @@ NWC.util.mapUtils = (function () {
 			geometryName: "the_geom",
 			srsName : "EPSG:3857"
 		});
-		var style = styleMap ? styleMap : new OpenLayers.StyleMap({
+		var style = style ? style : {
 				strokeWidth: 2,
-				strokeColor: "black",
-				fillOpacity: 0,
-				graphicOpacity: 1,
-				fill: false
-			});
+				strokeColor: "#000000",
+				fill : false
+			};
 
 		if (hucs.length === 1) {
 			filter = new OpenLayers.Filter.Comparison({
@@ -178,7 +176,7 @@ NWC.util.mapUtils = (function () {
 		hucLayer = new OpenLayers.Layer.Vector("WFS", {
 			strategies: [new OpenLayers.Strategy.Fixed()],
 			protocol: protocol,
-			styleMap: style,
+			style: style,
 			filter:filter
 		});
 		return hucLayer;

--- a/nwc/src/main/webapp/js/utils/mapUtils.js
+++ b/nwc/src/main/webapp/js/utils/mapUtils.js
@@ -131,7 +131,7 @@ NWC.util.mapUtils = (function () {
 
 	/*
 	 * @param {Array of String} hucs - to create in the feature layer. assuming all the same type.
-	 * @param {OpenLayers.StyleMap} styleMap - optional style map for the feature layer.
+	 * @param {Object} style - optional style for the feature layer.
 	 * @returns OpenLayers.Layer.Vector with hucs.
 	 */
 	that.createHucFeatureLayer = function(namespace, layerName, property, hucs, style) {
@@ -146,7 +146,7 @@ NWC.util.mapUtils = (function () {
 			geometryName: "the_geom",
 			srsName : "EPSG:3857"
 		});
-		var style = style ? style : {
+		var layerStyle = style ? style : {
 				strokeWidth: 2,
 				strokeColor: "#000000",
 				fill : false
@@ -176,7 +176,7 @@ NWC.util.mapUtils = (function () {
 		hucLayer = new OpenLayers.Layer.Vector("WFS", {
 			strategies: [new OpenLayers.Strategy.Fixed()],
 			protocol: protocol,
-			style: style,
+			style: layerStyle,
 			filter:filter
 		});
 		return hucLayer;

--- a/nwc/src/main/webapp/js/view/HucInsetMapView.js
+++ b/nwc/src/main/webapp/js/view/HucInsetMapView.js
@@ -40,6 +40,7 @@ NWC.view = NWC.view || {};
 			var accumulated = options.accumulated ? options.accumulated : false;
 			var watershedAcres = options.compare ? 'compareWatershedAcres' : 'watershedAcres';
 			var gageId = options.gageId ? options.gageId : null;
+			var hucId = options.hucId;
 
 			var watershedConfig = NWC.config.getWatershed(options.hucId);
 			var acWatershedConfig = NWC.config.get('accumulated').attributes;
@@ -54,14 +55,13 @@ NWC.view = NWC.view || {};
 
 			var gageLayer, gageMarkerLayer, hucLayer, achucLayer;
 
-			this.hucId = options.hucId;
 			this.hucStyle = accumulated ? ALT_HUC_STYLE : HUC_STYLE;
 			this.achucStyle = accumulated ? HUC_STYLE : ALT_HUC_STYLE;
 
 			this.context = {
-				hucId : this.hucId,
+				hucId : hucId,
 				gageId : gageId,
-				isHuc12 : this.hucId.length === 12
+				isHuc12 : hucId.length === 12
 			};
 
 			this.map = NWC.util.mapUtils.createMap([baseLayer], mapControls);
@@ -103,13 +103,13 @@ NWC.view = NWC.view || {};
 				watershedConfig.namespace,
 				watershedConfig.layerName,
 				watershedConfig.property,
-				[this.hucId],
+				[hucId],
 				this.hucStyle
 			);
 			hucLayer.events.on({
 				featureadded : function(event) {
 					var hucName = event.feature.attributes[watershedConfig.name];
-					var drainage = event.feature.attributes[watershedConfig.drainageArea]
+					var drainage = event.feature.attributes[watershedConfig.drainageArea];
 					this.$('.huc-name').html(hucName);
 					this.$('.local-drainage-area').html(drainage);
 				},
@@ -127,7 +127,7 @@ NWC.view = NWC.view || {};
 					acWatershedConfig.namespace,
 					acWatershedConfig.layerName,
 					acWatershedConfig.property,
-					[this.hucId],
+					[hucId],
 					this.achucStyle
 				);
 
@@ -176,18 +176,21 @@ NWC.view = NWC.view || {};
 				'opacity': this.hucStyle.strokeOpacity ,
 				'color' : this.hucStyle.strokeColor,
 				'font-size': '20px'
-			}
+			};
 			var achucLegendStyle = {
 				'opacity': this.achucStyle.strokeOpacity ,
 				'color' : this.achucStyle.strokeColor,
 				'font-size': '20px'
-			}
+			};
 
 			NWC.view.BaseView.prototype.render.apply(this, arguments);
-			this.map.render('huc-inset-' + this.hucId);
+			this.map.render('huc-inset-' + this.context.hucId);
 
 			this.$('.huc-legend span').css(hucLegendStyle);
 			this.$('.achuc-legend span').css(achucLegendStyle);
+			if (!this.context.gageId) {
+				this.$('.gage-legend').hide();
+			}
 
 			return this;
 		}

--- a/nwc/src/main/webapp/js/view/HucInsetMapView.js
+++ b/nwc/src/main/webapp/js/view/HucInsetMapView.js
@@ -18,6 +18,7 @@ NWC.view = NWC.view || {};
 		 *     @prop {String} hucId
 		 *     @prop {String} gageId (optional)
 		 *     @prop {Boolean} accumulated - false indicates if this is local watershed, true indicates accumulated.
+		 *     @prop {Boolean} compare - True if this is the comparision inset map view
 		 *     @prop {WaterBudgetHucPlotModel} model - Used to set the watershed acres
 		 */
 		initialize : function(options) {

--- a/nwc/src/main/webapp/js/view/HucInsetMapView.js
+++ b/nwc/src/main/webapp/js/view/HucInsetMapView.js
@@ -81,7 +81,7 @@ NWC.view = NWC.view || {};
 						var lonlat = new OpenLayers.LonLat(event.feature.geometry.x, event.feature.geometry.y);
 
 						this.model.set(watershedAcres,
-								NWC.util.Convert.squareKilometersToAcres(event.feature.attributes[watershedConfig.watershedAreaUnit]));
+								NWC.util.Convert.squareKilometersToAcres(event.feature.attributes[acWatershedConfig.watershedAreaUnit]));
 
 						gageMarkerLayer.addMarker(new OpenLayers.Marker(lonlat));
 

--- a/nwc/src/main/webapp/js/view/HucInsetMapView.js
+++ b/nwc/src/main/webapp/js/view/HucInsetMapView.js
@@ -53,7 +53,7 @@ NWC.view = NWC.view || {};
 			var baseLayer = NWC.util.mapUtils.createWorldStreetMapLayer();
 			var mapControls = [new OpenLayers.Control.Zoom(), new OpenLayers.Control.Navigation()];
 
-			var gageLayer, gageMarkerLayer, hucLayer, achucLayer;
+			var gageLayer, gageMarkerLayer;
 
 			this.hucStyle = accumulated ? ALT_HUC_STYLE : HUC_STYLE;
 			this.achucStyle = accumulated ? HUC_STYLE : ALT_HUC_STYLE;
@@ -99,14 +99,14 @@ NWC.view = NWC.view || {};
 				gageLoadedDeferred.resolve();
 			}
 
-			hucLayer = NWC.util.mapUtils.createHucFeatureLayer(
+			this.hucLayer = NWC.util.mapUtils.createHucFeatureLayer(
 				watershedConfig.namespace,
 				watershedConfig.layerName,
 				watershedConfig.property,
 				[hucId],
 				this.hucStyle
 			);
-			hucLayer.events.on({
+			this.hucLayer.events.on({
 				featureadded : function(event) {
 					var hucName = event.feature.attributes[watershedConfig.name];
 					var drainage = event.feature.attributes[watershedConfig.drainageArea];
@@ -115,7 +115,7 @@ NWC.view = NWC.view || {};
 				},
 				loadend : function(event) {
 					if (!accumulated) {
-						this.map.zoomToExtent(hucLayer.getDataExtent());
+						this.map.zoomToExtent(this.hucLayer.getDataExtent());
 					}
 					hucLoadedDeferred.resolve();
 				},
@@ -123,7 +123,7 @@ NWC.view = NWC.view || {};
 			});
 
 			if (this.context.isHuc12) {
-				achucLayer = NWC.util.mapUtils.createHucFeatureLayer(
+				this.achucLayer = NWC.util.mapUtils.createHucFeatureLayer(
 					acWatershedConfig.namespace,
 					acWatershedConfig.layerName,
 					acWatershedConfig.property,
@@ -131,7 +131,7 @@ NWC.view = NWC.view || {};
 					this.achucStyle
 				);
 
-				achucLayer.events.on({
+				this.achucLayer.events.on({
 					featureadded : function(event) {
 						var hucName = event.feature.attributes[acWatershedConfig.name];
 						var drainage = event.feature.attributes[acWatershedConfig.drainageArea];
@@ -140,7 +140,7 @@ NWC.view = NWC.view || {};
 					},
 					loadend : function(event) {
 						if (accumulated) {
-							this.map.zoomToExtent(achucLayer.getDataExtent());
+							this.map.zoomToExtent(this.achucLayer.getDataExtent());
 						}
 						achucLoadedDeferred.resolve();
 					},
@@ -152,15 +152,15 @@ NWC.view = NWC.view || {};
 			}
 
 			// Add the layer for the page's watershed last
-			if (accumulated && (achucLayer)) {
-				this.map.addLayer(hucLayer);
-				this.map.addLayer(achucLayer);
+			if (accumulated && (this.achucLayer)) {
+				this.map.addLayer(this.hucLayer);
+				this.map.addLayer(this.achucLayer);
 			}
 			else {
-				if (achucLayer) {
-					this.map.addLayer(achucLayer);
+				if (this.achucLayer) {
+					this.map.addLayer(this.achucLayer);
 				}
-				this.map.addLayer(hucLayer);
+				this.map.addLayer(this.hucLayer);
 			}
 
 			this.featureLoadedPromise.done(function() {

--- a/nwc/src/main/webapp/js/view/WaterBudgetHucDataView.js
+++ b/nwc/src/main/webapp/js/view/WaterBudgetHucDataView.js
@@ -45,7 +45,7 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 		this.fips = options.fips ? options.fips : '';
 
 		this.context.showAdditionalDataButtons = !(this.compareHucId || this.fips);
-		
+
 		this.context.featureToggles = NWC.config.get('featureToggles');
 
 		//if accumulated view only show the compare button
@@ -62,7 +62,7 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 		/*	Create additional sub views as needed
 		*	There are four variations of how this view is used
 		*	and the sub views are adjusted accordingly
-		*/ 
+		*/
 		$plotContainer = this.$('#huc-plot-container');
 		//	side by side comparison of an accumulated watershed
 		if (this.compareHucId && this.accumulated) {
@@ -76,11 +76,11 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 				gageId : this.gageId,
 				model : this.hucPlotModel
 			});
-			
+
 			/*	create the plot view after watershedAcres has been updated
 			*	by the HucInsetMap feature
-			*/ 
-			this.hucInsetMapView.gageFeatureLoadedPromise.done(function() {
+			*/
+			this.hucInsetMapView.featureLoadedPromise.done(function() {
 				self.plotView = new NWC.view.WaterbudgetPlotView({
 					accumulated : true,
 					hucId : self.hucId,
@@ -99,11 +99,11 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 				gageId : self.compareGageId,
 				model : self.hucPlotModel
 			});
-				
+
 			/*	create the compare plot view after watershedAcres has been updated
 			*	by the compare hucInsetMap feature
-			*/ 
-			self.compareHucInsetMapView.gageFeatureLoadedPromise.done(function() {
+			*/
+			self.compareHucInsetMapView.featureLoadedPromise.done(function() {
 				self.comparePlotView = new NWC.view.WaterbudgetPlotView({
 					accumulated : true,
 					compare : true,
@@ -150,8 +150,8 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 				gageId : this.gageId,
 				model : this.hucPlotModel
 			});
-			
-			this.hucInsetMapView.gageFeatureLoadedPromise.done(function() {
+
+			this.hucInsetMapView.featureLoadedPromise.done(function() {
 				self.plotView = new NWC.view.WaterbudgetPlotView({
 					accumulated : true,
 					hucId : self.hucId,
@@ -159,11 +159,11 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 					el : self.$('#huc-plot-container'),
 					model : self.hucPlotModel
 				});
-			});			
-			
-			this.hucInsetMapView.hucFeatureLoadedPromise.done(function() {
-				self.$('#compare-hucs-button').prop('disabled', false);				
-			});			
+			});
+
+			this.hucInsetMapView.featureLoadedPromise.done(function() {
+				self.$('#compare-hucs-button').prop('disabled', false);
+			});
 		}
 		//	huc data view of a local watershed
 		else {
@@ -172,7 +172,7 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 				hucId : this.hucId,
 				model : this.hucPlotModel
 			});
-			this.hucInsetMapView.hucFeatureLoadedPromise.done(function() {
+			this.hucInsetMapView.featureLoadedPromise.done(function() {
 				self.$('#accumulated-button').prop('disabled', false);
 				self.$('#counties-button').prop('disabled', false);
 				self.$('#compare-hucs-button').prop('disabled', false);
@@ -225,10 +225,10 @@ NWC.view.WaterBudgetHucDataView = NWC.view.BaseView.extend({
 
 	goToAddHucMapPage : function() {
 		if (this.accumulated) {
-			this.router.navigate('#!waterbudget/acmap/huc/' + this.hucId, {trigger: true});			
+			this.router.navigate('#!waterbudget/acmap/huc/' + this.hucId, {trigger: true});
 		}
 		else {
-			this.router.navigate('#!waterbudget/map/huc/' + this.hucId, {trigger: true});			
+			this.router.navigate('#!waterbudget/map/huc/' + this.hucId, {trigger: true});
 		}
 	},
 

--- a/nwc/src/main/webapp/js/view/WaterbudgetPlotView.js
+++ b/nwc/src/main/webapp/js/view/WaterbudgetPlotView.js
@@ -22,7 +22,8 @@ NWC.view = NWC.view || {};
 		 *      @prop {WaterBudgetHucPlotModel} model - Used to set the units and timeScaled of the plot.t
 		 *      @prop {String} gageId (optional)
 		 *      @prop {Boolean} accumulated - false indicates if this is local watershed, true indicates accumulated.
-		 *		@prop {WaterBudgetHucPlotModel} model - Used to get the watershed acres 
+		 *      @prop {Boolean} compare - True if this plot should use compareWatershedAcres rather than watershedAcres
+		 *		@prop {WaterBudgetHucPlotModel} model - Used to get the watershed acres
 		 * @returns {undefined}
 		 */
 		initialize : function(options) {
@@ -30,14 +31,14 @@ NWC.view = NWC.view || {};
 			this.hucId = options.hucId;
 			this.gageId = options.gageId ? options.gageId : null;
 			var accumulated = options.accumulated ? options.accumulated : false;
-			
+
 			if (accumulated) {
 				this.watershedVariables = NWC.config.get('accumulated').attributes.variables;
 			}
 			else {
 				this.watershedVariables = NWC.config.getWatershed(options.hucId).variables;
 			}
-			
+
 			this.compare = options.compare ? options.compare : false;
 
 			NWC.view.BaseView.prototype.initialize.apply(this, arguments);
@@ -54,7 +55,7 @@ NWC.view = NWC.view || {};
 		* This makes a Web service call to get huc data and transform it into a data series object.
 		* This will also make a web service call to get streamflow data if it is created as an
 		* accumulated type of view from the WaterBudgetHucDataView and there is an associated gage
-		* with the selected watershed. 
+		* with the selected watershed.
 		*
 		* @param {String} huc 12 digit identifier for the hydrologic unit
 		* @param {String} gageId (optional) identifier for the streamflow gage
@@ -73,16 +74,16 @@ NWC.view = NWC.view || {};
 				eta : this.watershedVariables.eta,
 				dayMet : this.watershedVariables.dayMet
 			};
-			
+
 			var acres;
 			//for an accumulated view, there may or may not be a gage
 			if (gage) {
-				/*	
+				/*
 				 *	Since there is a gage, the value for related acres will be
 				 *	retrieved from the model.  So, set the model variable
-				 *	for acres depending on whether or not the instance is for a 
+				 *	for acres depending on whether or not the instance is for a
 				 *	comparison type of the WaterBudgetHucDataView.
-				 */ 
+				 */
 				if (this.compare) {
 					acres = self.model.get('compareWatershedAcres');
 				}
@@ -99,11 +100,11 @@ NWC.view = NWC.view || {};
 
 			Object.keys(sosSources, function (sourceId, source) {
 				var d = $.Deferred();
-				
+
 				dataSeries[sourceId] = NWC.util.DataSeries.newSeries();
 				getDataDeferreds.push(d);
-				
-				if (sourceId === 'nwisStreamFlowData') {					
+
+				if (sourceId === 'nwisStreamFlowData') {
 					var startDate = '1838-01-01';
 					var parseDateStr = function(dateStr){
 						var tokens = dateStr.split('T');
@@ -180,7 +181,7 @@ NWC.view = NWC.view || {};
 							alert(errorMessage);
 							d.reject(errorMessage);
 						}
-					});	
+					});
 				}
 			});
 
@@ -197,7 +198,7 @@ NWC.view = NWC.view || {};
 		/**
 		 *	Update the plot with the current dataSeriesStore and model.
 		 *	If this is an accumulated type of view from the WaterBudgetHucDataView and there is
-		 *	an associated gage with the selected watershed, then streamflow will also be plotted. 
+		 *	an associated gage with the selected watershed, then streamflow will also be plotted.
 		 */
 		plotData : function() {
 			var self = this;

--- a/nwc/src/main/webapp/js/view/WaterbudgetPlotView.js
+++ b/nwc/src/main/webapp/js/view/WaterbudgetPlotView.js
@@ -58,7 +58,7 @@ NWC.view = NWC.view || {};
 		* with the selected watershed.
 		*
 		* @param {String} huc 12 digit identifier for the hydrologic unit
-		* @param {String} gageId (optional) identifier for the streamflow gage
+		* @param {String} gage (optional) identifier for the streamflow gage
 		* @returns a resolved promise when both ETA and DAYMET data has been retrieved and the dataSeriesStore updated. If
 		*      either call fails the promise will be rejected with either one or two error messages. The datasSeriesStore object will
 		*      contain the data for any successful calls

--- a/nwc/src/main/webapp/templates/hucInsetMap.html
+++ b/nwc/src/main/webapp/templates/hucInsetMap.html
@@ -37,6 +37,7 @@
 			<div class="inset-legend-container">
 				<div class="huc-legend">Local Incremental Watershed:&nbsp;&nbsp;<span>_</span></div>
 				<div class="achuc-legend">Total Accumulated Watershed:&nbsp;&nbsp;<span>_</span></div>
+				<div class="gage-legend">NWIS Gage:&nbsp;&nbsp;<img src="webjars/openlayers/2.12/img/marker.png" />
 			</div>
 		{{/if}}
 	</div>

--- a/nwc/src/main/webapp/templates/hucInsetMap.html
+++ b/nwc/src/main/webapp/templates/hucInsetMap.html
@@ -2,8 +2,8 @@
 	<div class="spacer_down ">
 		<h4 class="huc-loading-indicator">Loading huc data <i class="fa fa-spinner fa-spin"></i></h4>
 		<h4>Precipitation and Evapotranspiration for the Selected Watershed</h4>
-		<div class="row">
-			<div class="col-sm-6">
+		<div class="col-md-4">
+			<div>
 				<h5>Hydrologic Unit Code</h5>
 				<div class="huc-id">{{ hucId }}</div>
 				<h5>Watershed Name</h5>
@@ -15,7 +15,7 @@
 				{{/if}}
 			</div>
 		{{#if gageId}}
-			<div class="col-sm-6">
+			<div>
 				<h5>Gage ID</h5>
 				<div id="gage-id">{{ gageId }}</div>
 				<div>
@@ -31,7 +31,7 @@
 			</div>
 		{{/if}}
 	</div>
-	<div class="spacer_down spacer">
+	<div class="col-md-8 spacer_down spacer">
 		<div id="huc-inset-{{ hucId }}" class="inset-map"></div>
 		{{#if isHuc12}}
 			<div class="inset-legend-container">

--- a/nwc/src/main/webapp/templates/hucInsetMap.html
+++ b/nwc/src/main/webapp/templates/hucInsetMap.html
@@ -8,6 +8,11 @@
 				<div class="huc-id">{{ hucId }}</div>
 				<h5>Watershed Name</h5>
 				<div class="huc-name"></div>
+				{{#if isHuc12}}
+					<h5>Drainage Area (km<sup>2</sup>)</h5>
+					<div>Local Incremental - <span class="local-drainage-area"></span></div>
+					<div>Total Upstream - <span class="total-upstream-drainage-area"></span></div>
+				{{/if}}
 			</div>
 		{{#if gageId}}
 			<div class="col-sm-6">

--- a/nwc/src/main/webapp/templates/hucInsetMap.html
+++ b/nwc/src/main/webapp/templates/hucInsetMap.html
@@ -33,5 +33,11 @@
 	</div>
 	<div class="spacer_down spacer">
 		<div id="huc-inset-{{ hucId }}" class="inset-map"></div>
+		{{#if isHuc12}}
+			<div class="inset-legend-container">
+				<div class="huc-legend">Local Incremental Watershed:&nbsp;&nbsp;<span>_</span></div>
+				<div class="achuc-legend">Total Accumulated Watershed:&nbsp;&nbsp;<span>_</span></div>
+			</div>
+		{{/if}}
 	</div>
 </div>

--- a/nwc/src/main/webapp/templates/waterbudget.html
+++ b/nwc/src/main/webapp/templates/waterbudget.html
@@ -41,7 +41,7 @@
 		{{#if featureToggles.enableAccumulatedWaterBudget}}
 		<div class="row col-xs-12 pacer">
 			<a id="toggle-gage-layer" class="btn btn-primary" data-toggle="button">Turn Gages <span id="toggle-gage-layer-span">On</span></a>
-			<span>Turn on/off map-display of Stream Gages. Gages are for visual reference only</span>
+			<span>Observed runoff will be shown for watersheds containing a gage as shown by this layer.</span>
 		</div>
 		{{/if}}
 		<div class="row">

--- a/nwc/src/main/webapp/templates/waterbudgetHucData.html
+++ b/nwc/src/main/webapp/templates/waterbudgetHucData.html
@@ -9,31 +9,33 @@
 			</div>
 		</div>
 		<div class="row" id="wateruse"></div>		
-		<div class="row">
-			<div class="spacer col-md-6 col-md-push-6">
+		<div>
+			<div class="info-buttons spacer">
 				{{#if showAdditionalDataButtons}}
 					{{#if featureToggles.enableAccumulatedWaterBudget}}
 						{{#if showAccumulatedButton}}
-						<div>
+						<div class="button-div">
 							<button id="accumulated-button" class="btn btn-primary" disabled>Show Accumulated Water Budget <span class="glyphicon glyphicon-arrow-right"></span></button>
 						</div>
 						{{/if}}
 					{{/if}}
-					<div class="spacer">
+					<div class="button-div"">
 						<button id="compare-hucs-button" class="btn btn-primary" disabled>Select Watershed to Compare <span class="glyphicon glyphicon-arrow-right"></span></button>
 					</div>
 					{{#if showWaterUseButton}}
-					<div class="spacer">
+					<div  class="button-div">
 						<button id="counties-button" class="btn btn-primary" disabled>Plot County Water Use Data <span class="glyphicon glyphicon-arrow-down"></span></button>
 					</div>
 					{{/if}}
 				<div class="spacer" id="county-selection-div"></div>
 				{{/if}}
 			</div>
-			<div class="huc-inset-map-container col-md-6 col-md-pull-6 spacer spacer_down"></div>
+		</div>
+		<div>
+			<div class="huc-inset-map-container spacer spacer_down"></div>
 			<div class="compare-huc-inset-map-container space spacer-down col-sm-12">
-				<div class="huc-inset-map-div col-lg-offset-2 col-lg-4 col-md-6 col-sm-12" ></div>
-				<div class="comparehuc-inset-map-div col-lg-offset-2 col-lg-4 col-md-6 col-sm-12"></div>
+				<div class="huc-inset-map-div  col-md-6 col-sm-12" ></div>
+				<div class="comparehuc-inset-map-div col-md-6 col-sm-12"></div>
 			</div>
 		</div>
 		<div class="row">

--- a/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
@@ -11,7 +11,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 	var $customaryButton, $metricButton, $dailyButton, $monthlyButton;
 	var testView;
 	var server;
-	var hucFeatureLoadedDeferred, gageFeatureLoadedDeferred;
+	var featureLoadedDeferred;
 
 	beforeEach(function() {
 		CONFIG = {
@@ -40,19 +40,17 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		$countiesButton = $('#counties-button');
 		$accumulatedButton = $('#accumulated-button');
 		$compareHucsButton = $('#compare-hucs-button');
-		
+
 		spyOn(NWC.view.BaseView.prototype, 'initialize');
 
 		spyOn(NWC.view, 'WaterbudgetPlotView').andReturn({
 			remove : jasmine.createSpy('waterbudgetPlotViewRemoveSpy')
 		});
 
-		hucFeatureLoadedDeferred = $.Deferred();
-		gageFeatureLoadedDeferred = $.Deferred();
+		featureLoadedDeferred = $.Deferred();
 		spyOn(NWC.view, 'HucInsetMapView').andReturn({
 			remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
-			gageFeatureLoadedPromise : hucFeatureLoadedDeferred.promise(),
-			hucFeatureLoadedPromise : hucFeatureLoadedDeferred.promise()
+			featureLoadedPromise : featureLoadedDeferred.promise()
 		});
 
 		spyOn(NWC.view, 'CountyWaterUseView').andReturn({
@@ -113,7 +111,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		it('Expect that when the huc feature has been loaded that the counties button and compare hucs buttons are enabled', function() {
 			expect($countiesButton.prop('disabled')).toBe(true);
 			expect($compareHucsButton.prop('disabled')).toBe(true);
-			hucFeatureLoadedDeferred.resolve();
+			featureLoadedDeferred.resolve();
 			expect($countiesButton.prop('disabled')).toBe(false);
 			expect($compareHucsButton.prop('disabled')).toBe(false);
 		});
@@ -180,7 +178,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 				target : { value : 'monthly'}
 			});
 			expect(testView.hucPlotModel.get('timeScale')).toEqual('monthly');
-			
+
 			testView.changeTimeScale({
 				preventDefault : preventSpy,
 				target : { value : 'yearly'}
@@ -188,11 +186,11 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 			expect(testView.hucPlotModel.get('timeScale')).toEqual('yearly');
 		});
 	});
-	
+
 	describe('Test for view initialized with the accumulated option and hucID with corresponding gage', function() {
 		beforeEach(function() {
 			var watershedGages = NWC.config.get('watershedGages');
-			watershedGages.parse([{"hucId" : "123456789123", "gageId" : "02372250"}])
+			watershedGages.parse([{"hucId" : "123456789123", "gageId" : "02372250"}]);
 			testView = new NWC.view.WaterBudgetHucDataView({
 				hucId : '123456789123',
 				accumulated : true,
@@ -211,18 +209,17 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 			expect($countiesButton.prop('disabled')).toBe(true);
 			expect($accumulatedButton.prop('disabled')).toBe(true);
 			expect($compareHucsButton.prop('disabled')).toBe(true);
-			gageFeatureLoadedDeferred.resolve();
-			hucFeatureLoadedDeferred.resolve();
+			featureLoadedDeferred.resolve();
 			expect($countiesButton.prop('disabled')).toBe(true);
 			expect($accumulatedButton.prop('disabled')).toBe(true);
 			expect($compareHucsButton.prop('disabled')).toBe(false);
 		});
 	});
-	
+
 	describe('Test for view initialized with the accumulated option and hucID with no corresponding gage', function() {
 		beforeEach(function() {
 			var watershedGages = NWC.config.get('watershedGages');
-			watershedGages.parse([{"hucId" : "123456789", "gageId" : "02372250"}])
+			watershedGages.parse([{"hucId" : "123456789", "gageId" : "02372250"}]);
 			testView = new NWC.view.WaterBudgetHucDataView({
 				hucId : '123456789123',
 				accumulated : true,
@@ -241,8 +238,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 			expect($countiesButton.prop('disabled')).toBe(true);
 			expect($accumulatedButton.prop('disabled')).toBe(true);
 			expect($compareHucsButton.prop('disabled')).toBe(true);
-			gageFeatureLoadedDeferred.resolve();
-			hucFeatureLoadedDeferred.resolve();
+			featureLoadedDeferred.resolve();
 			expect($countiesButton.prop('disabled')).toBe(true);
 			expect($accumulatedButton.prop('disabled')).toBe(true);
 			expect($compareHucsButton.prop('disabled')).toBe(false);
@@ -257,8 +253,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 				compareHucId : '232323232323',
 				el : $testDiv
 			});
-			gageFeatureLoadedDeferred.resolve();
-			hucFeatureLoadedDeferred.resolve();
+			featureLoadedDeferred.resolve();
 		});
 
 		it('Expects that the context properties are set appropriately', function() {

--- a/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
@@ -48,10 +48,6 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		});
 
 		featureLoadedDeferred = $.Deferred();
-		spyOn(NWC.view, 'HucInsetMapView').andReturn({
-			remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
-			featureLoadedPromise : featureLoadedDeferred.promise()
-		});
 
 		spyOn(NWC.view, 'CountyWaterUseView').andReturn({
 			remove : jasmine.createSpy('countyWaterUsePlotViewRemoveSpy')
@@ -68,6 +64,10 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Test for view initialized only with a hucId', function() {
 		beforeEach(function() {
+			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
+				featureLoadedPromise : featureLoadedDeferred.promise()
+			});
 			testView = new NWC.view.WaterBudgetHucDataView({
 				hucId : '123456789',
 				el : $testDiv
@@ -189,6 +189,10 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Test for view initialized with the accumulated option and hucID with corresponding gage', function() {
 		beforeEach(function() {
+			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
+				featureLoadedPromise : featureLoadedDeferred.promise()
+			});
 			var watershedGages = NWC.config.get('watershedGages');
 			watershedGages.parse([{"hucId" : "123456789123", "gageId" : "02372250"}]);
 			testView = new NWC.view.WaterBudgetHucDataView({
@@ -218,8 +222,15 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Test for view initialized with the accumulated option and hucID with no corresponding gage', function() {
 		beforeEach(function() {
+			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
+				featureLoadedPromise : featureLoadedDeferred.promise()
+			});
 			var watershedGages = NWC.config.get('watershedGages');
-			watershedGages.parse([{"hucId" : "123456789", "gageId" : "02372250"}]);
+			watershedGages.parse([
+				{"hucId" : "123456789012", "gageId" : "02372250"},
+				{"hucId" : "987654321098", "gageId" : "02372250"}
+					]);
 			testView = new NWC.view.WaterBudgetHucDataView({
 				hucId : '123456789123',
 				accumulated : true,
@@ -247,13 +258,26 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Tests for view created with a compareHucId and accumulated watershed', function() {
 		beforeEach(function() {
+			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
+				featureLoadedPromise : {
+					done : function(fnc) {
+						fnc();
+					}
+				}
+			});
+			var watershedGages = NWC.config.get('watershedGages');
+			watershedGages.parse([
+				{"hucId" : "123456789012", "gageId" : "02372250"},
+				{"hucId" : "987654321098", "gageId" : "02372251"}
+			]);
+			NWC.config.set('watershedGages', watershedGages);
 			testView = new NWC.view.WaterBudgetHucDataView({
 				accumulated : true,
-				hucId : '123456789',
-				compareHucId : '232323232323',
+				hucId : '123456789012',
+				compareHucId : '987654321098',
 				el : $testDiv
 			});
-			featureLoadedDeferred.resolve();
 		});
 
 		it('Expects that the context properties are set appropriately', function() {
@@ -262,8 +286,8 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		it('Expects WaterBudgetPlotView to be called twice and that the view properties are defined', function() {
 			expect(NWC.view.WaterbudgetPlotView.calls.length).toBe(2);
-			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789');
-			expect(NWC.view.WaterbudgetPlotView.calls[1].args[0].hucId).toEqual('232323232323');
+			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789012');
+			expect(NWC.view.WaterbudgetPlotView.calls[1].args[0].hucId).toEqual('987654321098');
 			expect(testView.plotView).toBeDefined();
 			expect(testView.comparePlotView).toBeDefined();
 			expect(testView.countyWaterUseView).not.toBeDefined();
@@ -271,8 +295,8 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		it('Expects HucInsetMapView to be called twice and that the view properties are defined', function() {
 			expect(NWC.view.HucInsetMapView.calls.length).toBe(2);
-			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789');
-			expect(NWC.view.HucInsetMapView.calls[1].args[0].hucId).toEqual('232323232323');
+			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789012');
+			expect(NWC.view.HucInsetMapView.calls[1].args[0].hucId).toEqual('987654321098');
 			expect(testView.hucInsetMapView).toBeDefined();
 			expect(testView.compareHucInsetMapView).toBeDefined();
 		});
@@ -288,8 +312,16 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Tests for view created with a compareHucId', function() {
 		beforeEach(function() {
+			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
+				featureLoadedPromise : {
+					done : function(fnc) {
+						fnc();
+					}
+				}
+			});
 			testView = new NWC.view.WaterBudgetHucDataView({
-				hucId : '123456789',
+				hucId : '123456789012',
 				compareHucId : '232323232323',
 				el : $testDiv
 			});
@@ -301,7 +333,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		it('Expects WaterBudgetPlotView to be called twice and that the view properties are defined', function() {
 			expect(NWC.view.WaterbudgetPlotView.calls.length).toBe(2);
-			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789');
+			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789012');
 			expect(NWC.view.WaterbudgetPlotView.calls[1].args[0].hucId).toEqual('232323232323');
 			expect(testView.plotView).toBeDefined();
 			expect(testView.comparePlotView).toBeDefined();
@@ -310,7 +342,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		it('Expects HucInsetMapView to be called twice and that the view properties are defined', function() {
 			expect(NWC.view.HucInsetMapView.calls.length).toBe(2);
-			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789');
+			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789012');
 			expect(NWC.view.HucInsetMapView.calls[1].args[0].hucId).toEqual('232323232323');
 			expect(testView.hucInsetMapView).toBeDefined();
 			expect(testView.compareHucInsetMapView).toBeDefined();
@@ -327,6 +359,14 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Tests for view created with a fips', function() {
 		beforeEach(function() {
+			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
+				featureLoadedPromise : {
+					done : function(fnc) {
+						fnc();
+					}
+				}
+			});
 			testView = new NWC.view.WaterBudgetHucDataView({
 				hucId : '123456789',
 				fips : '9876',

--- a/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
@@ -271,7 +271,6 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 				{"hucId" : "123456789012", "gageId" : "02372250"},
 				{"hucId" : "987654321098", "gageId" : "02372251"}
 			]);
-			NWC.config.set('watershedGages', watershedGages);
 			testView = new NWC.view.WaterBudgetHucDataView({
 				accumulated : true,
 				hucId : '123456789012',


### PR DESCRIPTION
When showing huc12s we are now always showing both the accumulated and local watersheds on both the local and accumulated pages. They are styled differently depending on what kind of page is shown. Added a legend to distinguish the two polygons and added additional information.

This does not complete the ticket, but the rest of the changes are related to layout.