### PR TITLE
Watersmart 647

### DIFF
--- a/nwc/pom.xml
+++ b/nwc/pom.xml
@@ -84,20 +84,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.github.klieber</groupId>
-                <artifactId>phantomjs-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>install</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <version>1.9.2</version>
-                </configuration>
-            </plugin>
+			
 			<plugin>
 				<groupId>com.github.searls</groupId>
 				<artifactId>jasmine-maven-plugin</artifactId>
@@ -112,12 +99,6 @@
                 <configuration>
                     <keepServerAlive>true</keepServerAlive>
                     <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
-                    <webDriverCapabilities>
-						<capability>
-							<name>phantomjs.binary.path</name>
-							<value>${phantomjs.binary}</value>
-						</capability>
-					</webDriverCapabilities>
                     <jsSrcDir>${basedir}/src/main/webapp/js</jsSrcDir>
                     <jsTestSrcDir>${basedir}/src/test/javascript</jsTestSrcDir>
 					<preloadSources>

--- a/nwc/pom.xml
+++ b/nwc/pom.xml
@@ -1,11 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>nwc</artifactId>
-	<parent>
-		<artifactId>nwc-parent</artifactId>
-		<groupId>gov.usgs.cida.nwc</groupId>
-		<version>1.0.21-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <artifactId>nwc-parent</artifactId>
+        <groupId>gov.usgs.cida.nwc</groupId>
+        <version>1.0.21-SNAPSHOT</version>
+    </parent>
     <packaging>war</packaging>
 	
     <name>NWCUI</name>
@@ -31,24 +31,24 @@
                     <goal>process-resources</goal>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>net.alchim31.maven</groupId>
-				<artifactId>yuicompressor-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>compress</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<suffix>-${project.version}-min</suffix>
-					<excludes>
-						<exclude>**/FileSaver*.js</exclude>
-						<exclude>**/jquery.flot.*.js</exclude>
-					</excludes>
-				</configuration>  
-			</plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>yuicompressor-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compress</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <suffix>-${project.version}-min</suffix>
+                    <excludes>
+                        <exclude>**/FileSaver*.js</exclude>
+                        <exclude>**/jquery.flot.*.js</exclude>
+                    </excludes>
+                </configuration>  
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -85,10 +85,10 @@
                 </executions>
             </plugin>
 			
-			<plugin>
-				<groupId>com.github.searls</groupId>
-				<artifactId>jasmine-maven-plugin</artifactId>
-				<executions>
+            <plugin>
+                <groupId>com.github.searls</groupId>
+                <artifactId>jasmine-maven-plugin</artifactId>
+                <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
@@ -101,108 +101,108 @@
                     <webDriverClassName>org.openqa.selenium.phantomjs.PhantomJSDriver</webDriverClassName>
                     <jsSrcDir>${basedir}/src/main/webapp/js</jsSrcDir>
                     <jsTestSrcDir>${basedir}/src/test/javascript</jsTestSrcDir>
-					<preloadSources>
-						<source>webjars/jquery.js</source>
-						<source>webjars/bootstrap.js</source>
-						<source>webjars/select2.js</source>
-						<source>webjars/sugar.min.js</source>
-						<source>webjars/underscore.js</source>
-						<source>webjars/backbone.js</source>
-						<source>webjars/handlebars.js</source>
-						<source>webjars/OpenLayers.js</source>
-						<source>webjars/javascript.util.js</source>	
-						<source>webjars/jsts.js</source>
-						<source>${basedir}/src/main/webapp/vendorlibs/FileSaver.js-master/FileSaver.js</source>
-					</preloadSources>
-					<sourceIncludes>
-						<include>utils/*.js</include>
-						<include>model/BaseSelectMapModel.js</include>
-						<include>model/*.js</include>
-						<include>view/BaseView.js</include>
-						<include>view/BaseSelectMapView.js</include>
-						<include>view/BaseDiscoveryTabView.js</include>
-						<include>view/WaterbudgetPlotView.js</include>
-						<include>view/CountyWaterUseView.js</include>
-						<include>view/WaterBudgetHucDataView.js</include>
-						<include>view/ProjectTabView.js</include>
-						<include>view/DataTabView.js</include>
-						<include>view/PublicationsTabView.js</include>
-						<include>view/StreamflowPlotView.js</include>
-						<include>**/*.js</include>
-					</sourceIncludes>
-					<sourceExcludes>
-						<include>utils/openLayersExtensions/**/*.js</include>
-						<include>init.js</include>
-					</sourceExcludes>
-					<specExcludes>
-						<include>old_specs/*.js</include>
-					</specExcludes>
-				</configuration>		
-			</plugin>
-			<plugin>
+                    <preloadSources>
+                        <source>webjars/jquery.js</source>
+                        <source>webjars/bootstrap.js</source>
+                        <source>webjars/select2.js</source>
+                        <source>webjars/sugar.min.js</source>
+                        <source>webjars/underscore.js</source>
+                        <source>webjars/backbone.js</source>
+                        <source>webjars/handlebars.js</source>
+                        <source>webjars/OpenLayers.js</source>
+                        <source>webjars/javascript.util.js</source>	
+                        <source>webjars/jsts.js</source>
+                        <source>${basedir}/src/main/webapp/vendorlibs/FileSaver.js-master/FileSaver.js</source>
+                    </preloadSources>
+                    <sourceIncludes>
+                        <include>utils/*.js</include>
+                        <include>model/BaseSelectMapModel.js</include>
+                        <include>model/*.js</include>
+                        <include>view/BaseView.js</include>
+                        <include>view/BaseSelectMapView.js</include>
+                        <include>view/BaseDiscoveryTabView.js</include>
+                        <include>view/WaterbudgetPlotView.js</include>
+                        <include>view/CountyWaterUseView.js</include>
+                        <include>view/WaterBudgetHucDataView.js</include>
+                        <include>view/ProjectTabView.js</include>
+                        <include>view/DataTabView.js</include>
+                        <include>view/PublicationsTabView.js</include>
+                        <include>view/StreamflowPlotView.js</include>
+                        <include>**/*.js</include>
+                    </sourceIncludes>
+                    <sourceExcludes>
+                        <include>utils/openLayersExtensions/**/*.js</include>
+                        <include>init.js</include>
+                    </sourceExcludes>
+                    <specExcludes>
+                        <include>old_specs/*.js</include>
+                    </specExcludes>
+                </configuration>		
+            </plugin>
+            <plugin>
                 <groupId>com.github.timurstrekalov</groupId>
                 <artifactId>saga-maven-plugin</artifactId>
                 <version>1.5.3</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>coverage</goal>
-						</goals>
-					</execution>
-				</executions> 
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>coverage</goal>
+                        </goals>
+                    </execution>
+                </executions> 
                 <configuration>
                     <baseDir>http://localhost:${jasmine.serverPort}</baseDir>
                     <outputDir>${project.build.directory}/coverage</outputDir>
                     <noInstrumentPatterns>
                         <pattern>.*/.+_spec\.js</pattern>
-						<pattern>.*/client/*\.js</pattern>
-						<pattern>.*/openLayersExtensions/*/*\.js</pattern>
-						<pattern>.*/sinon.+\.js</pattern>
-						<!-- couldn't figure out how to exclude all webjars so doing them individually -->
-						<pattern>.*/jquery.js</pattern>
-						<pattern>.*/bootstrap.js</pattern>
-						<pattern>.*/select2.js</pattern>
-						<pattern>.*/sugar.min.js</pattern>
-						<pattern>.*/underscore.js</pattern>
-						<pattern>.*/backbone.js</pattern>
-						<pattern>.*/handlebars.js</pattern>
-						<pattern>.*/OpenLayers.js</pattern>
-						<pattern>.*/FileSaver.js</pattern>
-						<pattern>.*/javascript.util.js</pattern>
-						<pattern>.*/jsts.js</pattern>
-						<!-- Add patterns for files that don't need to be analyzed such as library files -->
+                        <pattern>.*/client/*\.js</pattern>
+                        <pattern>.*/openLayersExtensions/*/*\.js</pattern>
+                        <pattern>.*/sinon.+\.js</pattern>
+                        <!-- couldn't figure out how to exclude all webjars so doing them individually -->
+                        <pattern>.*/jquery.js</pattern>
+                        <pattern>.*/bootstrap.js</pattern>
+                        <pattern>.*/select2.js</pattern>
+                        <pattern>.*/sugar.min.js</pattern>
+                        <pattern>.*/underscore.js</pattern>
+                        <pattern>.*/backbone.js</pattern>
+                        <pattern>.*/handlebars.js</pattern>
+                        <pattern>.*/OpenLayers.js</pattern>
+                        <pattern>.*/FileSaver.js</pattern>
+                        <pattern>.*/javascript.util.js</pattern>
+                        <pattern>.*/jsts.js</pattern>
+                        <!-- Add patterns for files that don't need to be analyzed such as library files -->
                     </noInstrumentPatterns>
                 </configuration>
             </plugin>
-			<plugin>
-				<groupId>com.google.code.maven-replacer-plugin</groupId>
-				<artifactId>replacer</artifactId>
-				<version>1.5.3</version>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>replace</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<file>${project.build.directory}/coverage/total-coverage.dat</file>
-					<outputFile>${project.build.directory}/jasmine/total-coverage.dat</outputFile>
-					<regex>false</regex>
-					<token>src/</token>
-					<value>${project.basedir}/src/main/webapp/js/</value>
-				</configuration>
-			</plugin> 
+            <plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <file>${project.build.directory}/coverage/total-coverage.dat</file>
+                    <outputFile>${project.build.directory}/jasmine/total-coverage.dat</outputFile>
+                    <regex>false</regex>
+                    <token>src/</token>
+                    <value>${project.basedir}/src/main/webapp/js/</value>
+                </configuration>
+            </plugin> 
         </plugins>
         <finalName>${warName}</finalName>
     </build>
     <dependencies>
-		<dependency>
-			<groupId>gov.usgs.cida.nwc</groupId>
-			<artifactId>search-engine-files</artifactId>
-			<version>1.0.8</version>
-		</dependency>
+        <dependency>
+            <groupId>gov.usgs.cida.nwc</groupId>
+            <artifactId>search-engine-files</artifactId>
+            <version>1.0.8</version>
+        </dependency>
         <dependency>
             <groupId>gov.usgs.cida</groupId>
             <artifactId>dynamicProperties</artifactId>
@@ -240,26 +240,26 @@
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
         </dependency>
-	<dependency>
-		<groupId>org.mockito</groupId>
-		<artifactId>mockito-core</artifactId>
-		<version>1.10.19</version>
-		<scope>test</scope>
-	</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>gov.usgs.cida</groupId>
             <artifactId>proxy-utils</artifactId>
         </dependency>
-	<dependency>
-		<groupId>commons-codec</groupId>
-		<artifactId>commons-codec</artifactId>
-		<version>1.9</version>
-	</dependency>
-	<dependency>
-		<groupId>gov.usgs.cida.ajax_search_crawler_tools</groupId>
-		<artifactId>ajax_search_crawler_tools</artifactId>
-		<version>0.1.3</version>
-	</dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>gov.usgs.cida.ajax_search_crawler_tools</groupId>
+            <artifactId>ajax_search_crawler_tools</artifactId>
+            <version>0.1.3</version>
+        </dependency>
         <!-- ================================================================== -->
                 
         <!-- <webjars> -->
@@ -275,23 +275,23 @@
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>
-		<dependency>
+        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>select2</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>backbonejs</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>underscorejs</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>handlebars</artifactId>
-		</dependency>
-		<dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>backbonejs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>underscorejs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>handlebars</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>openlayers</artifactId>
         </dependency>
@@ -307,10 +307,10 @@
             <groupId>org.webjars</groupId>
             <artifactId>jsts</artifactId>
         </dependency>
-		<dependency>
-			<groupId>org.webjars</groupId>
-			<artifactId>dygraphs</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>dygraphs</artifactId>
+        </dependency>
         <!-- </webjars> -->
     </dependencies>
 </project>

--- a/nwc/src/main/webapp/index.jsp
+++ b/nwc/src/main/webapp/index.jsp
@@ -13,7 +13,6 @@
 				CONFIG.endpoint.direct = {};
 
 				//point to local proxies
-				CONFIG.endpoint.geoserver = CONFIG.contextPath + '/proxygeoserver/';
 				CONFIG.endpoint.thredds = CONFIG.contextPath + '/proxythredds/';
 				CONFIG.endpoint.wpsBase = CONFIG.contextPath + '/proxywps/';
 				CONFIG.endpoint.wps = CONFIG.endpoint.wpsBase + 'WebProcessingService'; //TODO inconsistant use of of URL resources

--- a/nwc/src/main/webapp/js/utils/mapUtils.js
+++ b/nwc/src/main/webapp/js/utils/mapUtils.js
@@ -118,7 +118,7 @@ NWC.util.mapUtils = (function () {
 
 	that.createHucLayer = function(namespace, layerName, config) {
 		return new OpenLayers.Layer.WMS('National WBD Snapshot',
-			CONFIG.endpoint.geoserver + 'gwc/service/wms',
+			CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 			{
 				layers: namespace + ':' + layerName,
 				transparent: true,
@@ -138,7 +138,7 @@ NWC.util.mapUtils = (function () {
 		var hucFilters = [];
 		var hucLayer;
 		var protocol = new OpenLayers.Protocol.WFS({
-			url : CONFIG.endpoint.geoserver + 'wfs',
+			url : CONFIG.endpoint.direct.geoserver + 'wfs',
 			featureType: layerName,
 			featureNS: "http://gov.usgs.cida/" + namespace,
 			version: "1.1.0",
@@ -189,7 +189,7 @@ NWC.util.mapUtils = (function () {
 		});
 
 		var protocol = new OpenLayers.Protocol.WFS({
-			url : CONFIG.endpoint.geoserver + 'wfs',
+			url : CONFIG.endpoint.direct.geoserver + 'wfs',
 			featureType: layerName,
 			featureNS: "http://gov.usgs.cida/" + namespace,
 			version: "1.1.0",
@@ -220,7 +220,7 @@ NWC.util.mapUtils = (function () {
 		});
 
 		var protocol = new OpenLayers.Protocol.WFS({
-			url : CONFIG.endpoint.geoserver + 'wfs',
+			url : CONFIG.endpoint.direct.geoserver + 'wfs',
 			featureType: layerName,
 			featureNS: "http://gov.usgs.cida/" + namespace,
 			version: "1.1.0",
@@ -244,7 +244,7 @@ NWC.util.mapUtils = (function () {
 		});
 
 		var protocol = new OpenLayers.Protocol.WFS({
-			url : CONFIG.endpoint.geoserver + 'wfs',
+			url : CONFIG.endpoint.direct.geoserver + 'wfs',
 			featureType: layerName,
 			featureNS: "http://gov.usgs.cida/" + namespace,
 			version: "1.1.0",
@@ -269,7 +269,7 @@ NWC.util.mapUtils = (function () {
 
 		var protocol = new OpenLayers.Protocol.WFS({
 			version: '1.1.0',
-			url: CONFIG.endpoint.geoserver + 'wfs',
+			url: CONFIG.endpoint.direct.geoserver + 'wfs',
 			featureType: layerName,
 			featureNS: 'http://gov.usgs.cida/' + namespace,
 			geometryName: 'the_geom',
@@ -304,7 +304,7 @@ NWC.util.mapUtils = (function () {
 
 	that.createFlowlinesLayer = function() {
 		return new OpenLayers.Layer.WMS('NHDPlus Flowlines',
-			CONFIG.endpoint.geoserver + 'gwc/service/wms',
+			CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 			{
 				layers : 'nhdplus:nhdflowline_network',
 				transparent : true,

--- a/nwc/src/main/webapp/js/view/AquaticBiologyMapView.js
+++ b/nwc/src/main/webapp/js/view/AquaticBiologyMapView.js
@@ -31,7 +31,7 @@ NWC.view = NWC.view || {};
 
 			this.bioDataSitesLayer = new OpenLayers.Layer.WMS(
 				"BioData Sites",
-					CONFIG.endpoint.geoserver + 'wms',
+					CONFIG.endpoint.direct.geoserver + 'wms',
 					{
 						layers: 'BioData:SiteInfo',
 						transparent: true
@@ -40,7 +40,7 @@ NWC.view = NWC.view || {};
 			);
 			this.gageFeatureLayer = new OpenLayers.Layer.WMS(
 				"Gage Location",
-				CONFIG.endpoint.geoserver + 'gwc/service/wms',
+				CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 				{
 					LAYERS: "NWC:gagesII",
 					STYLES: 'blue_circle',
@@ -56,7 +56,7 @@ NWC.view = NWC.view || {};
 			);
 			this.hucLayer = new OpenLayers.Layer.WMS(
 				"National WBD Snapshot",
-				CONFIG.endpoint.geoserver + 'gwc/service/wms',
+				CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 				{
 					layers: 'NWC:huc12_se_basins_v2_local',
 					transparent: true,
@@ -73,7 +73,7 @@ NWC.view = NWC.view || {};
 
 			var biodataProtocol  = new OpenLayers.Protocol.WFS({
 				version: "1.1.0",
-				url: CONFIG.endpoint.geoserver + 'wfs',
+				url: CONFIG.endpoint.direct.geoserver + 'wfs',
 				featureType: 'SiteInfo',
 				featureNS: 'http://gov.usgs.cida/BioData',
 				srsName: 'EPSG:900913',
@@ -81,13 +81,13 @@ NWC.view = NWC.view || {};
 			});
 
 			var gageProtocol = OpenLayers.Protocol.WFS.fromWMSLayer(this.gageFeatureLayer, {
-				url : CONFIG.endpoint.geoserver + "wfs",
+				url : CONFIG.endpoint.direct.geoserver + "wfs",
 				srsName : "EPSG:3857",
 				propertyNames: ["STAID","STANAME","DRAIN_SQKM","the_geom"]
 			});
 
 			var hucProtocol = OpenLayers.Protocol.WFS.fromWMSLayer(this.hucLayer, {
-				url : CONFIG.endpoint.geoserver + "wfs",
+				url : CONFIG.endpoint.direct.geoserver + "wfs",
 				srsName : "EPSG:3857",
 				propertyNames : ["huc12","drain_sqkm", "hu_12_name"]
 			});

--- a/nwc/src/main/webapp/js/view/BaseSelectMapView.js
+++ b/nwc/src/main/webapp/js/view/BaseSelectMapView.js
@@ -200,7 +200,7 @@ NWC.view = NWC.view || {};
 
 		legendUrl : function(layer, style) {
 			var thisStyle = (style) ? style : '';
-			return CONFIG.endpoint.geoserver + 'wms?request=GetLegendGraphic&format=image/png&width=20&height=20' +
+			return CONFIG.endpoint.direct.geoserver + 'wms?request=GetLegendGraphic&format=image/png&width=20&height=20' +
 				"&layer=" + layer + "&style=" + thisStyle +
 				"&legend_options=forceLabels:on;fontName:Times New Roman;fontAntiAliasing:true;fontColor:0x000033;fontSize:8px;bgColor:0xFFFFEE;dpi:100";
 		}

--- a/nwc/src/main/webapp/js/view/StreamflowStatsMapView.js
+++ b/nwc/src/main/webapp/js/view/StreamflowStatsMapView.js
@@ -37,7 +37,7 @@ NWC.view = NWC.view || {};
 
 			this.gagesLayer = new OpenLayers.Layer.WMS(
 				"Gage Location",
-				CONFIG.endpoint.geoserver + 'NWC/wms',
+				CONFIG.endpoint.direct.geoserver + 'NWC/wms',
 				{
 					LAYERS: gageConfig.namespace + ':' + gageConfig.layerName,
 					STYLES: 'blue_circle',
@@ -53,7 +53,7 @@ NWC.view = NWC.view || {};
 			);
 
 			this.hucLayer = new OpenLayers.Layer.WMS("National WBD Snapshot",
-				CONFIG.endpoint.geoserver + 'gwc/service/wms',
+				CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 				{
 					layers: huc12Config.namespace + ':' + huc12Config.localLayerName,
 					transparent: true,

--- a/nwc/src/main/webapp/js/view/WaterBudgetMapView.js
+++ b/nwc/src/main/webapp/js/view/WaterBudgetMapView.js
@@ -56,7 +56,7 @@ NWC.view = NWC.view || {};
 			var gageConfig = NWC.config.get('streamflow').gage.attributes;
 			this.gageLayer = new OpenLayers.Layer.WMS(
 				"Gage Location",
-				CONFIG.endpoint.geoserver + 'gwc/service/wms',
+				CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 				{
 					LAYERS: gageConfig.namespace + ':' + gageConfig.layerName,
 					format: 'image/png',
@@ -72,7 +72,7 @@ NWC.view = NWC.view || {};
 
 			var streamflowHuc12Config = NWC.config.get('streamflow').huc12.attributes;
 			this.modeledHucLayer = new OpenLayers.Layer.WMS("National WBD Snapshot",
-				CONFIG.endpoint.geoserver + 'gwc/service/wms',
+				CONFIG.endpoint.direct.geoserver + 'gwc/service/wms',
 				{
 					layers: streamflowHuc12Config.namespace + ':' + streamflowHuc12Config.localLayerName,
 					transparent: true,

--- a/nwc/src/main/webapp/js/view/WaterbudgetDownloadUpstreamView.js
+++ b/nwc/src/main/webapp/js/view/WaterbudgetDownloadUpstreamView.js
@@ -142,7 +142,7 @@ NWC.view = NWC.view || {};
 				};
 
 				$loadingAlert.addClass('hidden');
-				$.download(CONFIG.endpoint.geoserver + 'wfs', params, 'get');
+				$.download(CONFIG.endpoint.direct.geoserver + 'wfs', params, 'get');
 			}
 		}
 	});

--- a/nwc/src/test/javascript/specs/AquaticBiologyMapView_spec.js
+++ b/nwc/src/test/javascript/specs/AquaticBiologyMapView_spec.js
@@ -17,7 +17,9 @@ describe('Tests for NWC.view.AquaticBiologyMapView', function() {
 	beforeEach(function() {
 		window.CONFIG = {
 			endpoint : {
-				geoserver : 'http://fakeserver.com'
+				direct: {
+					geoserver : 'http://fakeserver.com'
+				}
 			}
 		};
 

--- a/nwc/src/test/javascript/specs/AquaticBiologyMapView_spec.js
+++ b/nwc/src/test/javascript/specs/AquaticBiologyMapView_spec.js
@@ -34,7 +34,7 @@ describe('Tests for NWC.view.AquaticBiologyMapView', function() {
 		addLayersSpy = jasmine.createSpy('addLayerSpy');
 		addLayerSpy = jasmine.createSpy('addLayerSpy');
 		spyOn(NWC.util.mapUtils, 'createFlowlinesLayer');
-		spyOn(NWC.view.BaseSelectMapView.prototype, 'initialize').andCallFake(function() {
+		spyOn(NWC.view.BaseSelectMapView.prototype, 'initialize').and.callFake(function() {
 			this.map = {
 				addLayers : addLayersSpy,
 				addLayer : addLayerSpy,

--- a/nwc/src/test/javascript/specs/AquaticBiologyPairView_spec.js
+++ b/nwc/src/test/javascript/specs/AquaticBiologyPairView_spec.js
@@ -60,7 +60,7 @@ describe('Tests for AquaticBiologyPairView', function() {
 	beforeEach(function() {
 		templateSpy = jasmine.createSpy('templateSpy');
 		NWC.templates = {
-			getTemplate : jasmine.createSpy('getTemplateSpy').andReturn(templateSpy)
+			getTemplate : jasmine.createSpy('getTemplateSpy').and.returnValue(templateSpy)
 		};
 		
 		$('body').append('<div id="test-div"></div>');

--- a/nwc/src/test/javascript/specs/AquaticBiologySelectFeaturesView_spec.js
+++ b/nwc/src/test/javascript/specs/AquaticBiologySelectFeaturesView_spec.js
@@ -74,7 +74,7 @@ describe('Tests for AquaticBiologySelectFeaturesView', function() {
 		
 		templateSpy = jasmine.createSpy('templateSpy');
 		NWC.templates = {
-			getTemplate : jasmine.createSpy('getTemplateSpy').andReturn(templateSpy)
+			getTemplate : jasmine.createSpy('getTemplateSpy').and.returnValue(templateSpy)
 		};
 		
 		spyOn(NWC.view.BaseView.prototype, 'initialize');
@@ -152,8 +152,8 @@ describe('Tests for AquaticBiologySelectFeaturesView', function() {
 	});
 	it('Expects AquaticBiologySelectFeaturesView.displayPairList to create AquaticBiologyPairViews', function(){	
 		var elSpy = jasmine.createSpy('elSpy');
-		renderSpy = jasmine.createSpy('renderSpy').andReturn(elSpy);		
-		spyOn(NWC.view,'AquaticBiologyPairView').andReturn({
+		renderSpy = jasmine.createSpy('renderSpy').and.returnValue(elSpy);		
+		spyOn(NWC.view,'AquaticBiologyPairView').and.returnValue({
 			render: renderSpy
 		});
 		

--- a/nwc/src/test/javascript/specs/BaseDiscoveryTabView_spec.js
+++ b/nwc/src/test/javascript/specs/BaseDiscoveryTabView_spec.js
@@ -32,7 +32,7 @@ describe('NWC.view.BaseDiscoveryTabView', function() {
 
 		templateSpy = jasmine.createSpy('templateSpy');
 		NWC.templates = {
-			getTemplate : jasmine.createSpy('getTemplateSpy').andReturn(templateSpy)
+			getTemplate : jasmine.createSpy('getTemplateSpy').and.returnValue(templateSpy)
 		};
 
 		spyOn(window, 'alert');
@@ -61,11 +61,11 @@ describe('NWC.view.BaseDiscoveryTabView', function() {
 	it('Expects the template to be rendered when a successful call is made using the data as the list property', function() {
 		server.respond([200, {'Content-Type' : 'application/json'}, testListResponse]);
 		expect(templateSpy).toHaveBeenCalled();
-		var args = templateSpy.calls[0].args[0];
-		expect(args.showSummary).toBe(true);
-		expect(args.toggleTitle).toBe(testView.SHOW_TITLE);
-		expect(args.toggleIcon).toBe(testView.SHOW_ICON);
-		expect(args.list).toEqual($.parseJSON(testListResponse).items);
+		var args = templateSpy.calls.argsFor(0);
+		expect(args[0].showSummary).toBe(true);
+		expect(args[0].toggleTitle).toBe(testView.SHOW_TITLE);
+		expect(args[0].toggleIcon).toBe(testView.SHOW_ICON);
+		expect(args[0].list).toEqual($.parseJSON(testListResponse).items);
 	});
 
 	it ('Expects that when the list request fails, the template is not rendered', function() {
@@ -108,22 +108,22 @@ describe('NWC.view.BaseDiscoveryTabView', function() {
 
 			expect(server.requests.length).toBe(2);
 			expect(server.requests[1].url).toEqual(testView.detailsUrl('1234'));
-			expect(NWC.templates.getTemplate.calls.length).toBe(1);
-			expect(templateSpy.calls.length).toBe(1);
+			expect(NWC.templates.getTemplate.calls.count()).toBe(1);
+			expect(templateSpy.calls.count()).toBe(1);
 
 			server.respond([200, {'Content-type' : 'application/json'}, testDetailResponse]);
-			expect(NWC.templates.getTemplate.calls.length).toBe(2);
-			expect(NWC.templates.getTemplate.calls[1].args).toEqual([testView.detailsTemplateName]);
-			expect(templateSpy.calls.length).toBe(2);
-			expect(templateSpy.calls[1].args).toEqual([$.parseJSON(testDetailResponse)]);
+			expect(NWC.templates.getTemplate.calls.count()).toBe(2);
+			expect(NWC.templates.getTemplate.calls.argsFor(1)).toEqual([testView.detailsTemplateName]);
+			expect(templateSpy.calls.count()).toBe(2);
+			expect(templateSpy.calls.argsFor(1)).toEqual([$.parseJSON(testDetailResponse)]);
 		});
 
 		it('Expects when the ajax call fails the template does not get rendered', function() {
 			testView.toggleDetails(ev);
 			server.respond([500, {'Content-type' : 'text/plain'}, "Server error"]);
 
-			expect(NWC.templates.getTemplate.calls.length).toBe(1);
-			expect(templateSpy.calls.length).toBe(1);
+			expect(NWC.templates.getTemplate.calls.count()).toBe(1);
+			expect(templateSpy.calls.count()).toBe(1);
 		});
 	});
 });

--- a/nwc/src/test/javascript/specs/BaseSelectMapView_spec.js
+++ b/nwc/src/test/javascript/specs/BaseSelectMapView_spec.js
@@ -12,7 +12,9 @@ describe('Tests for NWC.view.BaseSelectMapView', function() {
 	beforeEach(function() {
 		window.CONFIG = {
 			endpoint : {
-				geoserver : 'http://fakeserver.com'
+				direct: {
+					geoserver : 'http://fakeserver.com'
+				}
 			}
 		};
 

--- a/nwc/src/test/javascript/specs/BaseSelectMapView_spec.js
+++ b/nwc/src/test/javascript/specs/BaseSelectMapView_spec.js
@@ -49,8 +49,8 @@ describe('Tests for NWC.view.BaseSelectMapView', function() {
 		};
 
 		//mock methods that are used from NWC.util.mapUtils
-		spyOn(NWC.util.mapUtils, 'createMap').andReturn(mapSpy);
-		spyOn(NWC.util.mapUtils, 'createAllBaseLayers').andReturn([]);
+		spyOn(NWC.util.mapUtils, 'createMap').and.returnValue(mapSpy);
+		spyOn(NWC.util.mapUtils, 'createAllBaseLayers').and.returnValue([]);
 
 		spyOn($.fn, 'select2');
 
@@ -103,8 +103,8 @@ describe('Tests for NWC.view.BaseSelectMapView', function() {
 			view.model.set('control', 'zoom');
 			expect(view.zoomBoxControl.activate).toHaveBeenCalled();
 			expect(view.zoomBoxControl.deactivate).not.toHaveBeenCalled();
-			expect(view.selectControl.activate.calls.length).toBe(1);
-			expect(view.selectControl.deactivate.calls.length).toBe(1);
+			expect(view.selectControl.activate.calls.count()).toBe(1);
+			expect(view.selectControl.deactivate.calls.count()).toBe(1);
 
 			expect($zoomButton.hasClass('active')).toBe(true);
 			expect($selectButton.hasClass('active')).toBe(false);
@@ -114,10 +114,10 @@ describe('Tests for NWC.view.BaseSelectMapView', function() {
 		it('Expects the select box control to be activated when the model\'s control attribute is set to select', function() {
 			view.model.set('control', 'zoom');
 			view.model.set('control', 'select');
-			expect(view.zoomBoxControl.activate.calls.length).toBe(1);
-			expect(view.zoomBoxControl.deactivate.calls.length).toBe(1);
-			expect(view.selectControl.activate.calls.length).toBe(2);
-			expect(view.selectControl.deactivate.calls.length).toBe(1);
+			expect(view.zoomBoxControl.activate.calls.count()).toBe(1);
+			expect(view.zoomBoxControl.deactivate.calls.count()).toBe(1);
+			expect(view.selectControl.activate.calls.count()).toBe(2);
+			expect(view.selectControl.deactivate.calls.count()).toBe(1);
 
 			expect($zoomButton.hasClass('active')).toBe(false);
 			expect($selectButton.hasClass('active')).toBe(true);
@@ -128,8 +128,8 @@ describe('Tests for NWC.view.BaseSelectMapView', function() {
 			view.model.set('control', 'pan');
 			expect(view.zoomBoxControl.activate).not.toHaveBeenCalled();
 			expect(view.zoomBoxControl.deactivate).toHaveBeenCalled();
-			expect(view.selectControl.activate.calls.length).toBe(1);
-			expect(view.selectControl.deactivate.calls.length).toBe(1);
+			expect(view.selectControl.activate.calls.count()).toBe(1);
+			expect(view.selectControl.deactivate.calls.count()).toBe(1);
 
 			expect($zoomButton.hasClass('active')).toBe(false);
 			expect($selectButton.hasClass('active')).toBe(false);

--- a/nwc/src/test/javascript/specs/CountyWaterUseView_spec.js
+++ b/nwc/src/test/javascript/specs/CountyWaterUseView_spec.js
@@ -15,10 +15,12 @@ describe('Tests for CountyWaterUseView', function() {
 
 	beforeEach(function() {
 		CONFIG = {
-				endpoint : {
+			endpoint : {
+				direct: {
 					geoserver : 'http://fakeserver.com'
 				}
-			};
+			}
+		};
 		$('body').append('<div id="test-div"></div>');
 		$testDiv = $('#test-div');
 		$testDiv.append('<div id="county-inset-map-div"></div>');

--- a/nwc/src/test/javascript/specs/CountyWaterUseView_spec.js
+++ b/nwc/src/test/javascript/specs/CountyWaterUseView_spec.js
@@ -33,7 +33,7 @@ describe('Tests for CountyWaterUseView', function() {
 		$normalizedButton = $('#normalized-county-button');
 
 		// Stubbing the createMap call so OpenLayers does not try to make any ajax calls
-		spyOn(NWC.util.mapUtils, 'createMap').andCallFake(function() {
+		spyOn(NWC.util.mapUtils, 'createMap').and.callFake(function() {
 			return {
 				addLayer : jasmine.createSpy('addLayerSpy'),
 				zoomToExtent : jasmine.createSpy('zoomToExtentSpy'),
@@ -150,8 +150,8 @@ describe('Tests for CountyWaterUseView', function() {
 		testView.downloadWaterUse();
 
 		expect(saveAs).toHaveBeenCalled();
-		expect(saveAs.calls[0].args[1]).toMatch(testView.fileName);
-		expect(saveAs.calls[0].args[1]).toMatch(testView.fips);
+		expect(saveAs.calls.argsFor(0)[1]).toMatch(testView.fileName);
+		expect(saveAs.calls.argsFor(0)[1]).toMatch(testView.fips);
 		expect(testView.waterUseDataSeries.toCSV).toHaveBeenCalled();
 	});
 

--- a/nwc/src/test/javascript/specs/StreamflowCalculateStatsView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowCalculateStatsView_spec.js
@@ -23,13 +23,13 @@ describe('NWC.view.StreamflowCalculateStatsView', function() {
 
 		eventSpy = jasmine.createSpyObj('eventSpy', ['preventDefault']);
 		getStatsDeferred = $.Deferred();
-		getStatsSpy = jasmine.createSpy('getStatsSpy').andCallFake(function() {
+		getStatsSpy = jasmine.createSpy('getStatsSpy').and.callFake(function() {
 			return getStatsDeferred;
 		});
-		getStatsTsvHeaderSpy = jasmine.createSpy('getStatsHeaderSpy').andCallFake(function() {
+		getStatsTsvHeaderSpy = jasmine.createSpy('getStatsHeaderSpy').and.callFake(function() {
 			return "Fake Header";
 		});
-		getStatsFileNameSpy = jasmine.createSpy('getStatsFileNameSpy').andCallFake(function() {
+		getStatsFileNameSpy = jasmine.createSpy('getStatsFileNameSpy').and.callFake(function() {
 			return "stats.tsv";
 		});			
 		testView = new NWC.view.StreamflowCalculateStatsView({
@@ -81,16 +81,16 @@ describe('NWC.view.StreamflowCalculateStatsView', function() {
 			testView.calculateStats(eventSpy);
 
 			expect(testView.getStats).toHaveBeenCalled();
-			expect(testView.getStats.calls[0].args[0]).toEqual(['as1']);
-			expect(testView.getStats.calls[0].args[1]).toEqual(NWC.util.WaterYearUtil.waterYearStart('1991'));
-			expect(testView.getStats.calls[0].args[2]).toEqual(NWC.util.WaterYearUtil.waterYearEnd('1992'));
+			expect(testView.getStats.calls.argsFor(0)[0]).toEqual(['as1']);
+			expect(testView.getStats.calls.argsFor(0)[1]).toEqual(NWC.util.WaterYearUtil.waterYearStart('1991'));
+			expect(testView.getStats.calls.argsFor(0)[2]).toEqual(NWC.util.WaterYearUtil.waterYearEnd('1992'));
 		});
 
 		it('Expects the template to be rendered after the view\'s getStats function has been resolved', function() {
 			var templateSpy = jasmine.createSpy('templateSpy');
 			var statsResults = ['1', '2'];
 
-			getTemplateSpy.andReturn(templateSpy);
+			getTemplateSpy.and.returnValue(templateSpy);
 
 			testView.calculateStats(eventSpy);
 			expect(templateSpy).not.toHaveBeenCalled();
@@ -111,6 +111,6 @@ describe('NWC.view.StreamflowCalculateStatsView', function() {
 
 		expect(testView.getStatsTsv).toHaveBeenCalledWith("Fake Header");
 		expect(saveAs).toHaveBeenCalled();
-		expect(saveAs.calls[0].args[1]).toMatch('stats.tsv');
+		expect(saveAs.calls.argsFor(0)[1]).toMatch('stats.tsv');
 	});
 });

--- a/nwc/src/test/javascript/specs/StreamflowPlotView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowPlotView_spec.js
@@ -49,7 +49,7 @@ describe('NWC.view.StreamflowPlotView', function() {
 		expect($('.plot-loading-indicator').is(':visible')).toBe(false);
 		expect($('.plot-container').is(':visible')).toBe(true);
 		expect(NWC.util.Plotter.getPlot).toHaveBeenCalled();
-		var args = NWC.util.Plotter.getPlot.calls[0].args;
+		var args = NWC.util.Plotter.getPlot.calls.argsFor(0);
 		expect(args[5]).toEqual('this is a title');
 	});
 
@@ -61,7 +61,7 @@ describe('NWC.view.StreamflowPlotView', function() {
 
 		fetchDeferred.reject('An error message');
 		expect(resolveSpy).not.toHaveBeenCalled();
-		expect(errorSpy).toHaveBeenCalledWith(['An error message']);
+		expect(errorSpy.calls.argsFor(0)[0][0]).toEqual('An error message');
 
 		expect($('.plot-loading-indicator').is(':visible')).toBe(false);
 		expect($('.plot-container').is(':visible')).toBe(false);

--- a/nwc/src/test/javascript/specs/StreamflowStatsGageDataView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsGageDataView_spec.js
@@ -10,7 +10,9 @@ describe('Tests for StreamflowStatsGageDataView', function() {
 	beforeEach(function() {
 		CONFIG = {
 			endpoint : {
-				geoserver : 'http://fakeserver.com',
+				direct: {
+					geoserver : 'http://fakeserver.com'
+				},
 				nwis : 'http://fakenwis.org'
 			}
 		};

--- a/nwc/src/test/javascript/specs/StreamflowStatsGageDataView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsGageDataView_spec.js
@@ -103,7 +103,7 @@ describe('Tests for StreamflowStatsGageDataView', function() {
 		testView._retrieveNWISData();
 		expect(server.requests.length).toBe(requestCount + 1);
 		var thisRequest = server.requests.last();
-		expect(thisRequest.url).toMatch(CONFIG.endpoint.nwis);
+		expect(thisRequest.url).toMatch(CONFIG.endpoint.direct.nwis);
 		expect(thisRequest.url).toMatch(options.gageId);
 	});
 

--- a/nwc/src/test/javascript/specs/StreamflowStatsGageDataView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsGageDataView_spec.js
@@ -28,10 +28,10 @@ describe('Tests for StreamflowStatsGageDataView', function() {
 		spyOn(NWC.view.BaseView.prototype, 'render');
 		spyOn(NWC.view.BaseView.prototype, 'initialize');
 		plotStreamflowDataDeferred = $.Deferred();
-		spyOn(NWC.view, 'StreamflowPlotView').andReturn({
-			plotStreamflowData : jasmine.createSpy('plotStreamflowDataSpy').andReturn(plotStreamflowDataDeferred)
+		spyOn(NWC.view, 'StreamflowPlotView').and.returnValue({
+			plotStreamflowData : jasmine.createSpy('plotStreamflowDataSpy').and.returnValue(plotStreamflowDataDeferred)
 		});
-		spyOn(NWC.util.mapUtils, 'createMap').andCallFake(function() {
+		spyOn(NWC.util.mapUtils, 'createMap').and.callFake(function() {
 			return {
 				addLayers : addLayersSpy,
 				zoomToExtent : jasmine.createSpy('zoomToExtentSpy'),
@@ -70,13 +70,13 @@ describe('Tests for StreamflowStatsGageDataView', function() {
 		expect(testView.gageMarkerLayer).toBeDefined();
 
 		expect(addLayersSpy).toHaveBeenCalled();
-		expect(addLayersSpy.calls[0].args[0]).toContain(testView.gageLayer);
-		expect(addLayersSpy.calls[0].args[0]).toContain(testView.gageMarkerLayer);
+		expect(addLayersSpy.calls.argsFor(0)[0]).toContain(testView.gageLayer);
+		expect(addLayersSpy.calls.argsFor(0)[0]).toContain(testView.gageMarkerLayer);
 	});
 
 	it('Expects nwis data to be retrieved to fill in the start and end wateryear selects during initialization', function() {
 		var d = $.Deferred();
-		spyOn(NWC.view.StreamflowStatsGageDataView.prototype, '_retrieveNWISData').andCallFake(function() {
+		spyOn(NWC.view.StreamflowStatsGageDataView.prototype, '_retrieveNWISData').and.callFake(function() {
 			return d;
 		});
 		testView = new NWC.view.StreamflowStatsGageDataView(options);
@@ -139,13 +139,13 @@ describe('Tests for StreamflowStatsGageDataView', function() {
 			var doneSpy = jasmine.createSpy('doneSpy')
 			var d = testView.getStats(['s1', 's2'], '1990', '1991').done(doneSpy);
 			expect(NWC.util.streamStats.getSiteStats).toHaveBeenCalled();
-			expect(NWC.util.streamStats.getSiteStats.calls[0].args[0]).toEqual([options.gageId]);
-			expect(NWC.util.streamStats.getSiteStats.calls[0].args[1]).toEqual(['s1', 's2']);
-			expect(NWC.util.streamStats.getSiteStats.calls[0].args[2]).toEqual('1990');
-			expect(NWC.util.streamStats.getSiteStats.calls[0].args[3]).toEqual('1991');
+			expect(NWC.util.streamStats.getSiteStats.calls.argsFor(0)[0]).toEqual([options.gageId]);
+			expect(NWC.util.streamStats.getSiteStats.calls.argsFor(0)[1]).toEqual(['s1', 's2']);
+			expect(NWC.util.streamStats.getSiteStats.calls.argsFor(0)[2]).toEqual('1990');
+			expect(NWC.util.streamStats.getSiteStats.calls.argsFor(0)[3]).toEqual('1991');
 			expect(doneSpy).not.toHaveBeenCalled();
 
-			var callback = NWC.util.streamStats.getSiteStats.calls[0].args[4];
+			var callback = NWC.util.streamStats.getSiteStats.calls.argsFor(0)[4];
 			callback(['1', '2']);
 
 			expect(doneSpy).toHaveBeenCalledWith(['1', '2']);
@@ -166,7 +166,7 @@ describe('Tests for StreamflowStatsGageDataView', function() {
 
 	it('Expects a call to plotStreamFlowData to create, render and plot the flow data view, twice', function() {
 		var d = $.Deferred();
-		spyOn(NWC.view.StreamflowStatsGageDataView.prototype, '_retrieveNWISData').andCallFake(function() {
+		spyOn(NWC.view.StreamflowStatsGageDataView.prototype, '_retrieveNWISData').and.callFake(function() {
 			return d;
 		});
 		d.resolve({

--- a/nwc/src/test/javascript/specs/StreamflowStatsHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsHucDataView_spec.js
@@ -30,11 +30,11 @@ describe("Tests for NWC.view.StreamflowStatsHucDataView", function() {
 		renderSpy = jasmine.createSpy('renderSpy');
 		spyOn(NWC.view.BaseView.prototype, 'render');
 		plotStreamflowDataDeferred = $.Deferred();
-		spyOn(NWC.view, 'StreamflowPlotView').andReturn({
-			plotStreamflowData : jasmine.createSpy('plotStreamflowDataSpy').andReturn(plotStreamflowDataDeferred)
+		spyOn(NWC.view, 'StreamflowPlotView').and.returnValue({
+			plotStreamflowData : jasmine.createSpy('plotStreamflowDataSpy').and.returnValue(plotStreamflowDataDeferred)
 		});
 		spyOn(NWC.view.BaseView.prototype, 'initialize');
-		spyOn(NWC.util.mapUtils, 'createMap').andCallFake(function() {
+		spyOn(NWC.util.mapUtils, 'createMap').and.callFake(function() {
 			return {
 				addLayer : addLayerSpy,
 				zoomToExtent : jasmine.createSpy('zoomToExtentSpy'),
@@ -83,13 +83,13 @@ describe("Tests for NWC.view.StreamflowStatsHucDataView", function() {
 			var doneSpy = jasmine.createSpy('doneSpy');
 			var d = testView.getStats(['s1', 's2'], '1990', '1991').done(doneSpy);
 			expect(NWC.util.streamStats.getHucStats).toHaveBeenCalled();
-			expect(NWC.util.streamStats.getHucStats.calls[0].args[0]).toEqual(['123456789012']);
-			expect(NWC.util.streamStats.getHucStats.calls[0].args[1]).toEqual(['s1', 's2']);
-			expect(NWC.util.streamStats.getHucStats.calls[0].args[2]).toEqual('1990');
-			expect(NWC.util.streamStats.getHucStats.calls[0].args[3]).toEqual('1991');
+			expect(NWC.util.streamStats.getHucStats.calls.argsFor(0)[0]).toEqual(['123456789012']);
+			expect(NWC.util.streamStats.getHucStats.calls.argsFor(0)[1]).toEqual(['s1', 's2']);
+			expect(NWC.util.streamStats.getHucStats.calls.argsFor(0)[2]).toEqual('1990');
+			expect(NWC.util.streamStats.getHucStats.calls.argsFor(0)[3]).toEqual('1991');
 			expect(doneSpy).not.toHaveBeenCalled();
 
-			var callback = NWC.util.streamStats.getHucStats.calls[0].args[4];
+			var callback = NWC.util.streamStats.getHucStats.calls.argsFor(0)[4];
 			callback(['1', '2']);
 
 			expect(doneSpy).toHaveBeenCalledWith(['1', '2']);
@@ -115,8 +115,8 @@ describe("Tests for NWC.view.StreamflowStatsHucDataView", function() {
 		testView.downloadData(eventSpy);
 
 		expect(saveAs).toHaveBeenCalled();
-		expect(saveAs.calls[0].args[1]).toMatch(testView.hucName);
-		expect(saveAs.calls[0].args[1]).toMatch(testView.context.hucId);
+		expect(saveAs.calls.argsFor(0)[1]).toMatch(testView.hucName);
+		expect(saveAs.calls.argsFor(0)[1]).toMatch(testView.context.hucId);
 		expect(testView.dataSeries.toCSV).toHaveBeenCalled();
 	});
 
@@ -148,7 +148,7 @@ describe("Tests for NWC.view.StreamflowStatsHucDataView", function() {
 
 			testView.plotStreamFlowData(ev);
 			expect(testView.streamflowPlotViewLeft.plotStreamflowData).toHaveBeenCalled();
-			expect(testView.streamflowPlotViewLeft.plotStreamflowData.calls[0].args[0]).toMatch('Huc 12');
+			expect(testView.streamflowPlotViewLeft.plotStreamflowData.calls.argsFor(0)[0]).toMatch('Huc 12');
 		});
 	});
 });

--- a/nwc/src/test/javascript/specs/StreamflowStatsHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsHucDataView_spec.js
@@ -17,7 +17,9 @@ describe("Tests for NWC.view.StreamflowStatsHucDataView", function() {
 	beforeEach(function() {
 		CONFIG = {
 			endpoint : {
-				geoserver : 'http://fakeserver.com',
+				direct: {
+					geoserver : 'http://fakeserver.com'
+				},
 				thredds : 'http://fakesos.org/'
 			}
 		};

--- a/nwc/src/test/javascript/specs/StreamflowStatsMapView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsMapView_spec.js
@@ -29,7 +29,7 @@ describe('Test for NWC.view.StreamflowStatsMapView', function() {
 		addLayerSpy = jasmine.createSpy('addLayerSpy');
 		addControlSpy = jasmine.createSpy('addControlSpy');
 		spyOn(NWC.util.mapUtils, 'createFlowlinesLayer');
-		spyOn(NWC.view.BaseSelectMapView.prototype, 'initialize').andCallFake(function() {
+		spyOn(NWC.view.BaseSelectMapView.prototype, 'initialize').and.callFake(function() {
 			this.map = {
 				addLayers : addLayersSpy,
 				addLayer : addLayerSpy,
@@ -61,7 +61,7 @@ describe('Test for NWC.view.StreamflowStatsMapView', function() {
 
 		view.model.set('gageFilter', 'active');
 		expect($('#filter-label').html()).toEqual('Active');
-		expect(view.gagesLayer.addOptions.mostRecentCall.args[0].attribution).toMatch(view.model.getFilterStyle());
-		expect(view.gagesLayer.mergeNewParams.mostRecentCall.args[0].STYLES).toMatch(view.model.getFilterStyle());
+		expect(view.gagesLayer.addOptions.calls.mostRecent().args[0].attribution).toMatch(view.model.getFilterStyle());
+		expect(view.gagesLayer.mergeNewParams.calls.mostRecent().args[0].STYLES).toMatch(view.model.getFilterStyle());
 	});
 });

--- a/nwc/src/test/javascript/specs/StreamflowStatsMapView_spec.js
+++ b/nwc/src/test/javascript/specs/StreamflowStatsMapView_spec.js
@@ -12,7 +12,9 @@ describe('Test for NWC.view.StreamflowStatsMapView', function() {
 	beforeEach(function() {
 		window.CONFIG = {
 			endpoint : {
-				geoserver : 'http://fakeserver.com'
+				direct: {
+					geoserver : 'http://fakeserver.com'
+				}
 			}
 		};
 

--- a/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
@@ -44,17 +44,17 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		spyOn(NWC.view.BaseView.prototype, 'initialize');
 
-		spyOn(NWC.view, 'WaterbudgetPlotView').andReturn({
+		spyOn(NWC.view, 'WaterbudgetPlotView').and.returnValue({
 			remove : jasmine.createSpy('waterbudgetPlotViewRemoveSpy')
 		});
 
-		spyOn(NWC.view, 'WaterbudgetDownloadUpstreamView').andReturn({
+		spyOn(NWC.view, 'WaterbudgetDownloadUpstreamView').and.returnValue({
 			remove : jasmine.createSpy('waterbudgetDownloadUpstreamViewSpy')
 		});
 
 		featuresLoadedDeferred = $.Deferred();
 
-		spyOn(NWC.view, 'CountyWaterUseView').andReturn({
+		spyOn(NWC.view, 'CountyWaterUseView').and.returnValue({
 			remove : jasmine.createSpy('countyWaterUsePlotViewRemoveSpy')
 		});
 
@@ -69,7 +69,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Test for view initialized only with a hucId', function() {
 		beforeEach(function() {
-			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+			spyOn(NWC.view, 'HucInsetMapView').and.returnValue({
 				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
 				featuresLoadedPromise : featuresLoadedDeferred.promise()
 			});
@@ -93,7 +93,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		it('Expects the view\'s constructor to create a waterBudgetPlotView', function() {
 			expect(NWC.view.WaterbudgetPlotView).toHaveBeenCalled();
-			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789');
+			expect(NWC.view.WaterbudgetPlotView.calls.argsFor(0)[0].hucId).toEqual('123456789');
 			expect(testView.plotView).toBeDefined();
 			expect(testView.comparePlotView).not.toBeDefined();
 			expect(testView.countyWaterUseView).not.toBeDefined();
@@ -101,7 +101,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 		it('Expects the view\'s constructor to create create a hucInsetMapView', function() {
 			expect(NWC.view.HucInsetMapView).toHaveBeenCalled();
-			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789');
+			expect(NWC.view.HucInsetMapView.calls.argsFor(0)[0].hucId).toEqual('123456789');
 			expect(testView.hucInsetMapView).toBeDefined();
 			expect(testView.compareHucInsetMapView).not.toBeDefined();
 		});
@@ -194,7 +194,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Test for view initialized with the accumulated option and hucID with corresponding gage', function() {
 		beforeEach(function() {
-			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+			spyOn(NWC.view, 'HucInsetMapView').and.returnValue({
 				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
 				featuresLoadedPromise : featuresLoadedDeferred.promise()
 			});
@@ -227,13 +227,13 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		it('Expects that a WaterbudgetDownloadUpstreamView is created', function() {
 			featuresLoadedDeferred.resolve();
 			expect(NWC.view.WaterbudgetDownloadUpstreamView).toHaveBeenCalled();
-			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls[0].args[0].hucId).toEqual('123456789123');
+			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls.argsFor(0)[0].hucId).toEqual('123456789123');
 		});
 	});
 
 	describe('Test for view initialized with the accumulated option and hucID with no corresponding gage', function() {
 		beforeEach(function() {
-			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+			spyOn(NWC.view, 'HucInsetMapView').and.returnValue({
 				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
 				featuresLoadedPromise : featuresLoadedDeferred.promise()
 			});
@@ -269,7 +269,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Tests for view created with a compareHucId and accumulated watershed', function() {
 		beforeEach(function() {
-			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+			spyOn(NWC.view, 'HucInsetMapView').and.returnValue({
 				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
 				featuresLoadedPromise : {
 					done : function(fnc) {
@@ -295,26 +295,26 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		});
 
 		it('Expects WaterBudgetPlotView to be called twice and that the view properties are defined', function() {
-			expect(NWC.view.WaterbudgetPlotView.calls.length).toBe(2);
-			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789012');
-			expect(NWC.view.WaterbudgetPlotView.calls[1].args[0].hucId).toEqual('987654321098');
+			expect(NWC.view.WaterbudgetPlotView.calls.count()).toBe(2);
+			expect(NWC.view.WaterbudgetPlotView.calls.argsFor(0)[0].hucId).toEqual('123456789012');
+			expect(NWC.view.WaterbudgetPlotView.calls.argsFor(1)[0].hucId).toEqual('987654321098');
 			expect(testView.plotView).toBeDefined();
 			expect(testView.comparePlotView).toBeDefined();
 			expect(testView.countyWaterUseView).not.toBeDefined();
 		});
 
 		it('Expects WaterBudgetDownloadUpstreamView to be called twice and that the view properties are defined', function() {
-			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls.length).toBe(2);
-			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls[0].args[0].hucId).toEqual('123456789012');
-			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls[1].args[0].hucId).toEqual('987654321098');
+			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls.count()).toBe(2);
+			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls.argsFor(0)[0].hucId).toEqual('123456789012');
+			expect(NWC.view.WaterbudgetDownloadUpstreamView.calls.argsFor(1)[0].hucId).toEqual('987654321098');
 			expect(testView.downloadUpstreamView).toBeDefined();
 			expect(testView.compareDownloadUpstreamView).toBeDefined();
 		});
 
 		it('Expects HucInsetMapView to be called twice and that the view properties are defined', function() {
-			expect(NWC.view.HucInsetMapView.calls.length).toBe(2);
-			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789012');
-			expect(NWC.view.HucInsetMapView.calls[1].args[0].hucId).toEqual('987654321098');
+			expect(NWC.view.HucInsetMapView.calls.count()).toBe(2);
+			expect(NWC.view.HucInsetMapView.calls.argsFor(0)[0].hucId).toEqual('123456789012');
+			expect(NWC.view.HucInsetMapView.calls.argsFor(1)[0].hucId).toEqual('987654321098');
 			expect(testView.hucInsetMapView).toBeDefined();
 			expect(testView.compareHucInsetMapView).toBeDefined();
 		});
@@ -332,7 +332,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Tests for view created with a compareHucId', function() {
 		beforeEach(function() {
-			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+			spyOn(NWC.view, 'HucInsetMapView').and.returnValue({
 				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
 				featuresLoadedPromise : {
 					done : function(fnc) {
@@ -352,18 +352,18 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		});
 
 		it('Expects WaterBudgetPlotView to be called twice and that the view properties are defined', function() {
-			expect(NWC.view.WaterbudgetPlotView.calls.length).toBe(2);
-			expect(NWC.view.WaterbudgetPlotView.calls[0].args[0].hucId).toEqual('123456789012');
-			expect(NWC.view.WaterbudgetPlotView.calls[1].args[0].hucId).toEqual('232323232323');
+			expect(NWC.view.WaterbudgetPlotView.calls.count()).toBe(2);
+			expect(NWC.view.WaterbudgetPlotView.calls.argsFor(0)[0].hucId).toEqual('123456789012');
+			expect(NWC.view.WaterbudgetPlotView.calls.argsFor(1)[0].hucId).toEqual('232323232323');
 			expect(testView.plotView).toBeDefined();
 			expect(testView.comparePlotView).toBeDefined();
 			expect(testView.countyWaterUseView).not.toBeDefined();
 		});
 
 		it('Expects HucInsetMapView to be called twice and that the view properties are defined', function() {
-			expect(NWC.view.HucInsetMapView.calls.length).toBe(2);
-			expect(NWC.view.HucInsetMapView.calls[0].args[0].hucId).toEqual('123456789012');
-			expect(NWC.view.HucInsetMapView.calls[1].args[0].hucId).toEqual('232323232323');
+			expect(NWC.view.HucInsetMapView.calls.count()).toBe(2);
+			expect(NWC.view.HucInsetMapView.calls.argsFor(0)[0].hucId).toEqual('123456789012');
+			expect(NWC.view.HucInsetMapView.calls.argsFor(1)[0].hucId).toEqual('232323232323');
 			expect(testView.hucInsetMapView).toBeDefined();
 			expect(testView.compareHucInsetMapView).toBeDefined();
 		});
@@ -381,7 +381,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 
 	describe('Tests for view created with a fips', function() {
 		beforeEach(function() {
-			spyOn(NWC.view, 'HucInsetMapView').andReturn({
+			spyOn(NWC.view, 'HucInsetMapView').and.returnValue({
 				remove : jasmine.createSpy('waterBudgetHucInsetMapSpy'),
 				featuresLoadedPromise : {
 					done : function(fnc) {
@@ -402,7 +402,7 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 		});
 
 		it('Expects WaterBudgetPlotView to be called once, that CountyWaterUserView is called once and that the view properties are defined', function() {
-			expect(NWC.view.WaterbudgetPlotView.calls.length).toBe(1);
+			expect(NWC.view.WaterbudgetPlotView.calls.count()).toBe(1);
 			expect(NWC.view.CountyWaterUseView).toHaveBeenCalled();
 			expect(testView.plotView).toBeDefined();
 			expect(testView.comparePlotView).not.toBeDefined();

--- a/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterBudgetHucDataView_spec.js
@@ -17,7 +17,9 @@ describe('Tests for NWC.WaterBudgetHucDataView', function() {
 	beforeEach(function() {
 		CONFIG = {
 				endpoint : {
-					geoserver : 'http://fakeserver.com'
+					direct: {
+						geoserver : 'http://fakeserver.com'
+					}
 				}
 			};
 

--- a/nwc/src/test/javascript/specs/WaterBudgetMapView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterBudgetMapView_spec.js
@@ -18,7 +18,7 @@ describe('Tests for NWC.view.WaterBudgetMapView', function() {
 		addLayersSpy = jasmine.createSpy('addLayersSpy');
 		addControlSpy = jasmine.createSpy('addControlSpy');
 		spyOn(NWC.util.mapUtils, 'createFlowlinesLayer');
-		spyOn(NWC.view.BaseSelectMapView.prototype, 'initialize').andCallFake(function() {
+		spyOn(NWC.view.BaseSelectMapView.prototype, 'initialize').and.callFake(function() {
 			this.map = {
 				addLayer : addLayerSpy,
 				addLayers : addLayersSpy,

--- a/nwc/src/test/javascript/specs/WaterbudgetPlotView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterbudgetPlotView_spec.js
@@ -15,7 +15,9 @@ describe ('NWC.view.WaterbudgetPlotView', function() {
 	beforeEach(function() {
 		CONFIG = {
 			endpoint: {
-				geoserver : 'http:fakegeoserver.com',
+				geoserver : {
+					direct: 'http:fakegeoserver.com'
+				},
 				thredds : 'http://fakeservice'
 			}
 		};

--- a/nwc/src/test/javascript/specs/WaterbudgetPlotView_spec.js
+++ b/nwc/src/test/javascript/specs/WaterbudgetPlotView_spec.js
@@ -31,7 +31,7 @@ describe ('NWC.view.WaterbudgetPlotView', function() {
 
 		spyOn(NWC.view.BaseView.prototype, 'initialize');
 		spyOn(NWC.view.WaterbudgetPlotView.prototype, 'plotData');
-		spyOn(NWC.view.WaterbudgetPlotView.prototype, 'getPlotData').andCallThrough();
+		spyOn(NWC.view.WaterbudgetPlotView.prototype, 'getPlotData').and.callThrough();
 
 		toCSVSpy = jasmine.createSpy(toCSVSpy);
 
@@ -112,9 +112,9 @@ describe ('NWC.view.WaterbudgetPlotView', function() {
 		});
 
 		model.set('units', 'METRIC');
-		expect(NWC.view.WaterbudgetPlotView.prototype.plotData.calls.length).toBe(1);
+		expect(NWC.view.WaterbudgetPlotView.prototype.plotData.calls.count()).toBe(1);
 		model.set('timeScale', 'daily');
-		expect(NWC.view.WaterbudgetPlotView.prototype.plotData.calls.length).toBe(2);
+		expect(NWC.view.WaterbudgetPlotView.prototype.plotData.calls.count()).toBe(2);
 	});
 
 	it('Expects downloadEvapotranspiration to save to appropriate filename', function() {
@@ -132,8 +132,8 @@ describe ('NWC.view.WaterbudgetPlotView', function() {
 		testView.downloadEvapotranspiration();
 
 		expect(saveAs).toHaveBeenCalled();
-		expect(saveAs.calls[0].args[1]).toMatch(testView.hucId);
-		expect(saveAs.calls[0].args[1]).toMatch('_eta');
+		expect(saveAs.calls.argsFor(0)[1]).toMatch(testView.hucId);
+		expect(saveAs.calls.argsFor(0)[1]).toMatch('_eta');
 		expect(toCSVSpy).toHaveBeenCalled();
 	});
 
@@ -152,8 +152,8 @@ describe ('NWC.view.WaterbudgetPlotView', function() {
 		testView.downloadPrecipitation();
 
 		expect(saveAs).toHaveBeenCalled();
-		expect(saveAs.calls[0].args[1]).toMatch(testView.hucId);
-		expect(saveAs.calls[0].args[1]).toMatch('_dayMet');
+		expect(saveAs.calls.argsFor(0)[1]).toMatch(testView.hucId);
+		expect(saveAs.calls.argsFor(0)[1]).toMatch('_dayMet');
 		expect(toCSVSpy).toHaveBeenCalled();
 	});
 });

--- a/nwc/src/test/javascript/specs/templateLoader_spec.js
+++ b/nwc/src/test/javascript/specs/templateLoader_spec.js
@@ -21,11 +21,11 @@ describe('Tests for templateLoader', function() {
 
 	it('Expects loadTemplate to return a deferred', function() {
 		var loadSpy = jasmine.createSpy('loadSpy');
-		spyOn($, 'ajax').andCallThrough();
+		spyOn($, 'ajax').and.callThrough();
 		loader.loadTemplates(['home', 'next']).always(loadSpy);
-		expect($.ajax.calls.length).toBe(2);
-		expect($.ajax.calls[0].args[0].url).toMatch('home.html');
-		expect($.ajax.calls[1].args[0].url).toMatch('next.html');
+		expect($.ajax.calls.count()).toBe(2);
+		expect($.ajax.calls.argsFor(0)[0].url).toMatch('home.html');
+		expect($.ajax.calls.argsFor(1)[0].url).toMatch('next.html');
 		expect(loadSpy).not.toHaveBeenCalled();
 	});
 

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
 				<plugin>
 					<groupId>com.github.searls</groupId>
 					<artifactId>jasmine-maven-plugin</artifactId>
-					<version>1.3.1.5</version>
+					<version>2.2</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION
Had to update the jasmine-maven-plugin which required updating the jasmine tests to run with jasmine 2.x rather than 1.x

Code no longer uses the geoserver proxy and instead uses the direct url.